### PR TITLE
chore: testnet-2 tabs

### DIFF
--- a/pages/controller/add-evm-chain.md
+++ b/pages/controller/add-evm-chain.md
@@ -69,34 +69,48 @@ axelard q evm address avalanche --key-role secondary
 Register external governance keys for the new chain.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      axelard tx tss register-external-keys avalanche --from controller \
-        --key avax-external-1:03e4da05dd2c4d1a75567fff2ade93de82ccca8701689ce42da40cebd4cc7a2423 \
-        --key avax-external-2:03dccf1720dafc44d6e47635b8f0e2705bd57346acce1f18238580461fd3c900ce \
-        --key avax-external-3:0383afc1b42f1dae34649ab70c4c3d67aa86db89fc1842cd697e3c2a574b433ab1 \
-        --key avax-external-4:02ad55f4054d47a13cfe2583693bf63a8f299ca33da936f7372a38070cbf5dbc93 \
-        --key avax-external-5:02e25f07aca8971908b7489b54d809401c34d1d5a817b521234ced5b75c056f2fd \
-        --key avax-external-6:023f39b9bfcead2854bab63f02880487553430a475ee0f3783c52ef98927cb37d7 \
-        --key avax-external-7:03e78bbe19444fe98a77b45c340998437fb902572747f8e44ea99b23dc1106e0d2 \
-        --key avax-external-8:0203ce85d1564ce9203b45ad6b93511c8daaa0927f31f3e8d53f18b51afc3f7a27
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      axelard tx tss register-external-keys avalanche --from controller \
-        --key avax-external-1:041bb2e070cdd8490500f673136f95d80bf4eb9ac6a85fe8fede6070515d75dfd51a7187318aeb17eb53e711a8ccc0939bbda30ac67836969b64422ef6831a6e2a \
-        --key avax-external-2:040626a1032fe1f76deb3b4f0cb5c68cc0e29264102111077691478d74eafcdc4c3938bb712b7d8cd15f9c72261432be19217f02e445d4caeb09d7a1abe793642e \
-        --key avax-external-3:04d8400ac69c6c919d6963a5da6403ba750f5d7859b0c00f1a6b9a2ce9cd663bf8a20af0351f0e6dbc7bc41040c06156d02b78f25fd6b9b54db03bd53e812b8577 \
-        --key avax-external-4:04ee60261b7fd4084b271618cefef4f9a4093338a1dfbeae2f4a18366a53a07dd0657f31fa38c2739885fbc9ee1e83e25b3fcda6581be8f82400c7d0a18eb79070 \
-        --key avax-external-5:04aebaae5d1c63bf527331ee9a75dbc727420f51bc557a78dd0d9a0227c42dad2d821c9a3b24ca75b558b3c333cb8e4acaa4fb174a07ebd8268c6a43b83e04ffdc \
-        --key avax-external-6:04900ccd93432b25f4758f8d702bfd91e6192b0931345baafa50328185300a4cd0e392398612f5394fd6026f06fa73fb42a4f43ced2fa5ef326e5d658fd90113d3 \
-        --key avax-external-7:04761c872fd2c9c501e75ba3ef8fd65ed4d0f1e7ba60901f758b26645ee3621256a65df63f10b009f1f0e458e7cdb69737098cc30e99cf41887d7adc24c9492729 \
-        --key avax-external-8:044202188712caa9c047caaa01eb2a97f631b5ffb0ac1e2de40609c89137d7992a07d7b6c48cb69eee0323855377582a5601008a1190ca6c2b37316c2aead28bfd
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+axelard tx tss register-external-keys avalanche --from controller \
+ --key avax-external-1:03e4da05dd2c4d1a75567fff2ade93de82ccca8701689ce42da40cebd4cc7a2423 \
+ --key avax-external-2:03dccf1720dafc44d6e47635b8f0e2705bd57346acce1f18238580461fd3c900ce \
+ --key avax-external-3:0383afc1b42f1dae34649ab70c4c3d67aa86db89fc1842cd697e3c2a574b433ab1 \
+ --key avax-external-4:02ad55f4054d47a13cfe2583693bf63a8f299ca33da936f7372a38070cbf5dbc93 \
+ --key avax-external-5:02e25f07aca8971908b7489b54d809401c34d1d5a817b521234ced5b75c056f2fd \
+ --key avax-external-6:023f39b9bfcead2854bab63f02880487553430a475ee0f3783c52ef98927cb37d7 \
+ --key avax-external-7:03e78bbe19444fe98a77b45c340998437fb902572747f8e44ea99b23dc1106e0d2 \
+ --key avax-external-8:0203ce85d1564ce9203b45ad6b93511c8daaa0927f31f3e8d53f18b51afc3f7a27
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+axelard tx tss register-external-keys avalanche --from controller \
+ --key avax-external-1:041bb2e070cdd8490500f673136f95d80bf4eb9ac6a85fe8fede6070515d75dfd51a7187318aeb17eb53e711a8ccc0939bbda30ac67836969b64422ef6831a6e2a \
+ --key avax-external-2:040626a1032fe1f76deb3b4f0cb5c68cc0e29264102111077691478d74eafcdc4c3938bb712b7d8cd15f9c72261432be19217f02e445d4caeb09d7a1abe793642e \
+ --key avax-external-3:04d8400ac69c6c919d6963a5da6403ba750f5d7859b0c00f1a6b9a2ce9cd663bf8a20af0351f0e6dbc7bc41040c06156d02b78f25fd6b9b54db03bd53e812b8577 \
+ --key avax-external-4:04ee60261b7fd4084b271618cefef4f9a4093338a1dfbeae2f4a18366a53a07dd0657f31fa38c2739885fbc9ee1e83e25b3fcda6581be8f82400c7d0a18eb79070 \
+ --key avax-external-5:04aebaae5d1c63bf527331ee9a75dbc727420f51bc557a78dd0d9a0227c42dad2d821c9a3b24ca75b558b3c333cb8e4acaa4fb174a07ebd8268c6a43b83e04ffdc \
+ --key avax-external-6:04900ccd93432b25f4758f8d702bfd91e6192b0931345baafa50328185300a4cd0e392398612f5394fd6026f06fa73fb42a4f43ced2fa5ef326e5d658fd90113d3 \
+ --key avax-external-7:04761c872fd2c9c501e75ba3ef8fd65ed4d0f1e7ba60901f758b26645ee3621256a65df63f10b009f1f0e458e7cdb69737098cc30e99cf41887d7adc24c9492729 \
+ --key avax-external-8:044202188712caa9c047caaa01eb2a97f631b5ffb0ac1e2de40609c89137d7992a07d7b6c48cb69eee0323855377582a5601008a1190ca6c2b37316c2aead28bfd
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+axelard tx tss register-external-keys avalanche --from controller \
+ --key avax-external-1:041bb2e070cdd8490500f673136f95d80bf4eb9ac6a85fe8fede6070515d75dfd51a7187318aeb17eb53e711a8ccc0939bbda30ac67836969b64422ef6831a6e2a \
+ --key avax-external-2:040626a1032fe1f76deb3b4f0cb5c68cc0e29264102111077691478d74eafcdc4c3938bb712b7d8cd15f9c72261432be19217f02e445d4caeb09d7a1abe793642e \
+ --key avax-external-3:04d8400ac69c6c919d6963a5da6403ba750f5d7859b0c00f1a6b9a2ce9cd663bf8a20af0351f0e6dbc7bc41040c06156d02b78f25fd6b9b54db03bd53e812b8577 \
+ --key avax-external-4:04ee60261b7fd4084b271618cefef4f9a4093338a1dfbeae2f4a18366a53a07dd0657f31fa38c2739885fbc9ee1e83e25b3fcda6581be8f82400c7d0a18eb79070 \
+ --key avax-external-5:04aebaae5d1c63bf527331ee9a75dbc727420f51bc557a78dd0d9a0227c42dad2d821c9a3b24ca75b558b3c333cb8e4acaa4fb174a07ebd8268c6a43b83e04ffdc \
+ --key avax-external-6:04900ccd93432b25f4758f8d702bfd91e6192b0931345baafa50328185300a4cd0e392398612f5394fd6026f06fa73fb42a4f43ced2fa5ef326e5d658fd90113d3 \
+ --key avax-external-7:04761c872fd2c9c501e75ba3ef8fd65ed4d0f1e7ba60901f758b26645ee3621256a65df63f10b009f1f0e458e7cdb69737098cc30e99cf41887d7adc24c9492729 \
+ --key avax-external-8:044202188712caa9c047caaa01eb2a97f631b5ffb0ac1e2de40609c89137d7992a07d7b6c48cb69eee0323855377582a5601008a1190ca6c2b37316c2aead28bfd
+</CodeBlock>
+}
 ]} />
 
 The gateway contract can now be deployed on the new EVM chain.

--- a/pages/learn/cli/axl-from-evm.md
+++ b/pages/learn/cli/axl-from-evm.md
@@ -21,18 +21,24 @@ Redeem AXL tokens from an EVM chain to Axelar using the terminal.
 Link your Axelar `validator` account to a new temporary deposit address on the EVM chain:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx evm link {EVM_CHAIN} axelarnet {VALIDATOR_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"my-secret-password | ~/.axelar_testnet/bin/axelard tx evm link {EVM_CHAIN} axelarnet {VALIDATOR_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx evm link {EVM_CHAIN} axelarnet {VALIDATOR_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"my-secret-password | ~/.axelar_testnet/bin/axelard tx evm link {EVM_CHAIN} axelarnet {VALIDATOR_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm link {EVM_CHAIN} axelarnet {VALIDATOR_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -44,18 +50,24 @@ successfully linked {EVM_TEMP_ADDR} and {VALIDATOR_ADDR}
 Optional: query your new `{EVM_TEMP_ADDR}`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q nexus latest-deposit-address {EVM_CHAIN} axelarnet {VALIDATOR_ADDR}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q nexus latest-deposit-address {EVM_CHAIN} axelarnet {VALIDATOR_ADDR}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q nexus latest-deposit-address {EVM_CHAIN} axelarnet {VALIDATOR_ADDR}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q nexus latest-deposit-address {EVM_CHAIN} axelarnet {VALIDATOR_ADDR}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q nexus latest-deposit-address {EVM_CHAIN} axelarnet {VALIDATOR_ADDR}"}
+</CodeBlock>
+}
 ]} />
 
 Use Metamask to send some wrapped AXL tokens on `{EVM_CHAIN}` to the new temporary deposit address `{EVM_TEMP_ADDR}`. Save the transaction hash `{EVM_TX_HASH}` for later.
@@ -67,13 +79,13 @@ Use Metamask to send some wrapped AXL tokens on `{EVM_CHAIN}` to the new tempora
 <Callout emoji="📝">
   Note: Third-party monitoring tools will automatically complete the remaining steps of this process.
 
-  Wait a few minutes then check your Axelar `validator` account AXL token balance as per [Basic node management](/node/basic).
+Wait a few minutes then check your Axelar `validator` account AXL token balance as per [Basic node management](/node/basic).
 </Callout>
 
 <Callout type="warning" emoji="⚠️">
   Caution: If you attempt the remaining steps while third-party monitoring tools are active then your commands are likely to conflict with third-party commands. In this case you are likely to observe errors. Deeper investigation might be needed to resolve conflicts and complete the transfer.
 
-  The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
+The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
 </Callout>
 
 Do not proceed to the next step until you have waited for sufficiently many block confirmations on the EVM chain. Block confirmation minimums can be found at [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
@@ -81,18 +93,24 @@ Do not proceed to the next step until you have waited for sufficiently many bloc
 Confirm the EVM chain transaction on Axelar.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Wait for confirmation on Axelar.
@@ -100,37 +118,50 @@ Wait for confirmation on Axelar.
 Optional: Search the axelar-core logs for confirmation:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      tail -f ~/.axelar/logs/axelard.log | grep -a -e "deposit confirmation"
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      tail -f ~/.axelar_testnet/logs/axelard.log | grep -a -e "deposit confirmation"
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+tail -f ~/.axelar/logs/axelard.log | grep -a -e "deposit confirmation"
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+tail -f ~/.axelar_testnet/logs/axelard.log | grep -a -e "deposit confirmation"
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+tail -f ~/.axelar_testnet-2/logs/axelard.log | grep -a -e "deposit confirmation"
+</CodeBlock>
+}
 ]} />
 
 Create and sign pending transfers for `{EVM_CHAIN}`.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core --gas auto --gas-adjustment 1.5
+echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -142,18 +173,24 @@ successfully started signing batched commands with ID {BATCH_ID}
 Get the `execute_data`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+}
 ]} />
 
 Wait for `status: BATCHED_COMMANDS_STATUS_SIGNED` and copy the `execute_data`.
@@ -167,32 +204,38 @@ Use Metamask to send a transaction on `{EVM_CHAIN}` with the `execute_data` to t
 <Callout type="warning" emoji="⚠️">
   Caution: Manually increase the gas limit to 5 million gas (5000000). If you don't do this then the transaction will fail due to insufficient gas and you will not receive your tokens.
 
-  Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
+Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
 </Callout>
 
 <Callout emoji="💡">
   Tip: Learn the Axelar `{GATEWAY_ADDR}` for `{EVM_CHAIN}` in two ways:
 
-  ### 1. Documentation
+### 1. Documentation
 
-  [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
+[Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
 
-  ### 2. Terminal
+### 2. Terminal
 
-  <Tabs tabs={[
-    {
-      title: "Mainnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    },
-    {
-      title: "Testnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    }
-  ]} />
+<Tabs tabs={[
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+}
+]} />
 </Callout>
 
 To send a transaction to `{GATEWAY_ADDR}` using Metamask: paste hex from `execute_data` above into "Hex Data" field. (Do not send tokens!)
@@ -202,18 +245,24 @@ Optional: Check your Axelar `validator` account AXL token balance as per [Basic 
 Execute the pending transfer:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet execute-pending-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet execute-pending-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet execute-pending-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet execute-pending-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet execute-pending-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 You should see the redeemed `{AMOUNT}` of AXL token (minus transaction fees) in your Axelar `validator` account.

--- a/pages/learn/cli/axl-to-evm.md
+++ b/pages/learn/cli/axl-to-evm.md
@@ -33,18 +33,24 @@ Optional: Verify that your `validator` account has sufficient balance as per [Ba
 Link your `{EVM_DEST_ADDR}` to a new temporary deposit address on Axelar:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -56,83 +62,108 @@ successfully linked {AXELAR_TEMP_ADDR} and {EVM_DEST_ADDR}
 Optional: query your new `{AXELAR_TEMP_ADDR}`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q nexus latest-deposit-address axelarnet {EVM_CHAIN} {EVM_DEST_ADDR}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q nexus latest-deposit-address axelarnet {EVM_CHAIN} {EVM_DEST_ADDR}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q nexus latest-deposit-address axelarnet {EVM_CHAIN} {EVM_DEST_ADDR}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q nexus latest-deposit-address axelarnet {EVM_CHAIN} {EVM_DEST_ADDR}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q nexus latest-deposit-address axelarnet {EVM_CHAIN} {EVM_DEST_ADDR}"}
+</CodeBlock>
+}
 ]} />
 
 Send `{AMOUNT}` of `uaxl` to the new `{AXELAR_TEMP_ADDR}`.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx bank send validator {AXELAR_TEMP_ADDR} {AMOUNT}uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx bank send validator {AXELAR_TEMP_ADDR} {AMOUNT}uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx bank send validator {AXELAR_TEMP_ADDR} {AMOUNT}uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx bank send validator {AXELAR_TEMP_ADDR} {AMOUNT}uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx bank send validator {AXELAR_TEMP_ADDR} {AMOUNT}uaxl --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 <Callout emoji="📝">
   Note: Third-party monitoring tools will automatically complete the remaining steps of this process.
 
-  Wait a few minutes then check your Metamask for the AXL tokens. Don't forget to import the AXL token into Metamask so you can see your balance as described in [Metamask for EVM chains](/resources/metamask).
+Wait a few minutes then check your Metamask for the AXL tokens. Don't forget to import the AXL token into Metamask so you can see your balance as described in [Metamask for EVM chains](/resources/metamask).
 </Callout>
 
 <Callout type="warning" emoji="⚠️">
   Caution: If you attempt the remaining steps while third-party monitoring tools are active then your commands are likely to conflict with third-party commands. In this case you are likely to observe errors. Deeper investigation might be needed to resolve conflicts and complete the transfer.
 
-  The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
+The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
 </Callout>
 
 Confirm the deposit transaction. Look for `{TX_HASH}` in the output of the previous command.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}uaxl {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}uaxl {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}uaxl {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}uaxl {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}uaxl {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Create and sign pending transfers for `{EVM_CHAIN}`.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core --gas auto --gas-adjustment 1.5
+echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -144,18 +175,24 @@ successfully started signing batched commands with ID {BATCH_ID}
 Get the `execute_data`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+}
 ]} />
 
 Wait for `status: BATCHED_COMMANDS_STATUS_SIGNED` and copy the `execute_data`.
@@ -169,32 +206,38 @@ Use Metamask to send a transaction on `{EVM_CHAIN}` with the `execute_data` to t
 <Callout type="warning" emoji="⚠️">
   Caution: Manually increase the gas limit to 5 million gas (5000000). If you don't do this then the transaction will fail due to insufficient gas and you will not receive your tokens.
 
-  Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
+Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
 </Callout>
 
 <Callout emoji="💡">
   Tip: Learn the Axelar `{GATEWAY_ADDR}` for `{EVM_CHAIN}` in two ways:
 
-  ### 1. Documentation
+### 1. Documentation
 
-  [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
+[Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
 
-  ### 2. Terminal
+### 2. Terminal
 
-  <Tabs tabs={[
-    {
-      title: "Mainnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    },
-    {
-      title: "Testnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    }
-  ]} />
+<Tabs tabs={[
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+}
+]} />
 </Callout>
 
 To send a transaction to `{GATEWAY_ADDR}` using Metamask: paste hex from `execute_data` above into "Hex Data" field. (Do not send tokens!)

--- a/pages/learn/cli/ust-from-evm.md
+++ b/pages/learn/cli/ust-from-evm.md
@@ -22,18 +22,24 @@ Redeem UST tokens from an EVM chain to Terra using the terminal.
 Link your `{TERRA_DEST_ADDR}` address to a new temporary deposit address on the EVM chain:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx evm link {EVM_CHAIN} terra {TERRA_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm link {EVM_CHAIN} terra {TERRA_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx evm link {EVM_CHAIN} terra {TERRA_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm link {EVM_CHAIN} terra {TERRA_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm link {EVM_CHAIN} terra {TERRA_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -51,13 +57,13 @@ Use Metamask to send some wrapped AXL tokens on `{EVM_CHAIN}` to the new tempora
 <Callout emoji="📝">
   Note: Third-party monitoring tools will automatically complete the remaining steps of this process.
 
-  Wait a few minutes then check your Terra `{TERRA_DEST_ADDR}` account UST token balance.
+Wait a few minutes then check your Terra `{TERRA_DEST_ADDR}` account UST token balance.
 </Callout>
 
 <Callout type="warning" emoji="⚠️">
   Caution: If you attempt the remaining steps while third-party monitoring tools are active then your commands are likely to conflict with third-party commands. In this case you are likely to observe errors. Deeper investigation might be needed to resolve conflicts and complete the transfer.
 
-  The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
+The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
 </Callout>
 
 Do not proceed to the next step until you have waited for sufficiently many block confirmations on the EVM chain. Block confirmation minimums can be found at [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
@@ -65,18 +71,24 @@ Do not proceed to the next step until you have waited for sufficiently many bloc
 Confirm the EVM chain transaction on Axelar.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm confirm-erc20-deposit {EVM_CHAIN} {EVM_TX_HASH} {AMOUNT} {EVM_TEMP_ADDR} --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Wait for confirmation on Axelar.
@@ -84,20 +96,27 @@ Wait for confirmation on Axelar.
 Create and sign pending transfers for `{EVM_CHAIN}`.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm create-burn-tokens {EVM_CHAIN} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core --gas auto --gas-adjustment 1.5
+echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -109,18 +128,24 @@ successfully started signing batched commands with ID {BATCH_ID}
 Get the `execute_data`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+}
 ]} />
 
 Wait for `status: BATCHED_COMMANDS_STATUS_SIGNED` and copy the `execute_data`.
@@ -134,32 +159,38 @@ Use Metamask to send a transaction on `{EVM_CHAIN}` with the `execute_data` to t
 <Callout type="warning" emoji="⚠️">
   Caution: Manually increase the gas limit to 5 million gas (5000000). If you don't do this then the transaction will fail due to insufficient gas and you will not receive your tokens.
 
-  Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
+Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
 </Callout>
 
 <Callout emoji="💡">
   Tip: Learn the Axelar `{GATEWAY_ADDR}` for `{EVM_CHAIN}` in two ways:
 
-  ### 1. Documentation
+### 1. Documentation
 
-  [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
+[Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
 
-  ### 2. Terminal
+### 2. Terminal
 
-  <Tabs tabs={[
-    {
-      title: "Mainnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    },
-    {
-      title: "Testnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    }
-  ]} />
+<Tabs tabs={[
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+}
+]} />
 </Callout>
 
 To send a transaction to `{GATEWAY_ADDR}` using Metamask: paste hex from `execute_data` above into "Hex Data" field. (Do not send tokens!)
@@ -167,18 +198,24 @@ To send a transaction to `{GATEWAY_ADDR}` using Metamask: paste hex from `execut
 Execute the pending IBC transfer:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet route-ibc-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet route-ibc-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet route-ibc-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet route-ibc-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet route-ibc-transfers --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Wait a few minutes for the IBC relayer to relay your transaction to Terra.

--- a/pages/learn/cli/ust-to-evm.md
+++ b/pages/learn/cli/ust-to-evm.md
@@ -21,18 +21,24 @@ Transfer UST tokens from Terra to an EVM chain using the terminal.
 Link your `{EVM_DEST_ADDR}` to a new temporary deposit address on Axelar:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet link {EVM_CHAIN} {EVM_DEST_ADDR} uusd --from validator --gas auto --gas-adjustment 1.5 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -46,18 +52,19 @@ Send UST tokens from Terra to your temporary Axelar address `{AXELAR_TEMP_ADDR}`
 <Callout emoji="ℹ️">
   Info: There are several ways to do IBC.
 
-  ### IBC from a web wallet
+### IBC from a web wallet
 
-  Use a web wallet such as Keplr. See [Transfer Terra assets to EVM chains using Satellite | Axelar Network](https://axelar.network/transfer-terra-assets-to-evm-chains-using-satellite).
+Use a web wallet such as Keplr. See [Transfer Terra assets to EVM chains using Satellite | Axelar Network](https://axelar.network/transfer-terra-assets-to-evm-chains-using-satellite).
 
-  ### IBC from the terminal
+### IBC from the terminal
 
-  You need shell access to a Terra node with at least `{AMOUNT}` balance of UST tokens in an account called `terra-validator`.
-  Get `{TERRA_TO_AXELAR_CHANNEL_ID}` from [Testnet resources](/resources/testnet) or [Mainnet resources](resources/mainnet).
+You need shell access to a Terra node with at least `{AMOUNT}` balance of UST tokens in an account called `terra-validator`.
+Get `{TERRA_TO_AXELAR_CHANNEL_ID}` from [Testnet resources](/resources/testnet) or [Mainnet resources](resources/mainnet).
 
-  ```bash
-  terrad tx ibc-transfer transfer transfer {TERRA_TO_AXELAR_CHANNEL_ID} {AXELAR_TEMP_ADDR} --packet-timeout-timestamp 0 --packet-timeout-height "0-20000" {AMOUNT}uusd --gas-prices 0.15uusd --from terra-validator -y -b block
-  ```
+```bash
+terrad tx ibc-transfer transfer transfer {TERRA_TO_AXELAR_CHANNEL_ID} {AXELAR_TEMP_ADDR} --packet-timeout-timestamp 0 --packet-timeout-height "0-20000" {AMOUNT}uusd --gas-prices 0.15uusd --from terra-validator -y -b block
+```
+
 </Callout>
 
 Wait a few minutes for the IBC relayer to relay your transaction to Axelar.
@@ -65,13 +72,13 @@ Wait a few minutes for the IBC relayer to relay your transaction to Axelar.
 <Callout emoji="📝">
   Note: Third-party monitoring tools will automatically complete the remaining steps of this process.
 
-  Wait a few minutes then check your Metamask for the UST tokens. Don't forget to import the UST token into Metamask so you can see your balance as described in [Metamask for EVM chains](/resources/metamask).
+Wait a few minutes then check your Metamask for the UST tokens. Don't forget to import the UST token into Metamask so you can see your balance as described in [Metamask for EVM chains](/resources/metamask).
 </Callout>
 
 <Callout type="warning" emoji="⚠️">
   Caution: If you attempt the remaining steps while third-party monitoring tools are active then your commands are likely to conflict with third-party commands. In this case you are likely to observe errors. Deeper investigation might be needed to resolve conflicts and complete the transfer.
 
-  The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
+The remaining steps are needed only if there are no active third-party monitoring tools and you wish to complete the process manually.
 </Callout>
 
 Verify the IBC transaction by checking the balances of `{AXELAR_TEMP_ADDR}` as per [Basic node management](/node/basic). Output should contain something like:
@@ -93,37 +100,50 @@ The remaining steps are similar to [Transfer AXL tokens from Axelar to an EVM ch
 Confirm the deposit transaction. Look for `{TX_HASH}` in the output of the previous command.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {`echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}"{IBC_DENOM}" {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}"{IBC_DENOM}" {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}"{IBC_DENOM}" {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}"{IBC_DENOM}" {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx axelarnet confirm-deposit {TX_HASH} {AMOUNT}"{IBC_DENOM}" {AXELAR_TEMP_ADDR} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 Create and sign pending transfers for `{EVM_CHAIN}`.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core --gas auto --gas-adjustment 1.5
 echo my-secret-password | ~/.axelar_testnet/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm create-pending-transfers {EVM_CHAIN} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core --gas auto --gas-adjustment 1.5
+echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx evm sign-commands {EVM_CHAIN} --from validator --gas auto --gas-adjustment 1.2 --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 Output should contain
@@ -135,18 +155,24 @@ successfully started signing batched commands with ID {BATCH_ID}
 Get the `execute_data`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm batched-commands {EVM_CHAIN} {BATCH_ID}"}
+</CodeBlock>
+}
 ]} />
 
 Wait for `status: BATCHED_COMMANDS_STATUS_SIGNED` and copy the `execute_data`.
@@ -160,32 +186,38 @@ Use Metamask to send a transaction on `{EVM_CHAIN}` with the `execute_data` to t
 <Callout type="warning" emoji="⚠️">
   Caution: Manually increase the gas limit to 5 million gas (5000000). If you don't do this then the transaction will fail due to insufficient gas and you will not receive your tokens.
 
-  Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
+Before you click "confirm": select "EDIT", change "Gas Limit" to 5000000, and "Save"
 </Callout>
 
 <Callout emoji="💡">
   Tip: Learn the Axelar `{GATEWAY_ADDR}` for `{EVM_CHAIN}` in two ways:
 
-  ### 1. Documentation
+### 1. Documentation
 
-  [Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
+[Testnet resources](/resources/testnet), [Mainnet resources](/resources/mainnet).
 
-  ### 2. Terminal
+### 2. Terminal
 
-  <Tabs tabs={[
-    {
-      title: "Mainnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    },
-    {
-      title: "Testnet",
-      content: <CodeBlock language="bash">
-        {"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
-      </CodeBlock>
-    }
-  ]} />
+<Tabs tabs={[
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q evm gateway-address {EVM_CHAIN}"}
+</CodeBlock>
+}
+]} />
 </Callout>
 
 To send a transaction to `{GATEWAY_ADDR}` using Metamask: paste hex from `execute_data` above into "Hex Data" field. (Do not send tokens!)

--- a/pages/node/basic.md
+++ b/pages/node/basic.md
@@ -30,18 +30,24 @@ kill -9 $(pgrep -f "axelard start")
 </Callout>
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-     {"cp -r ~/.axelar ~/.axelar_mainnet_backup"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"cp -r ~/.axelar_testnet ~/.axelar_testnet_backup"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"cp -r ~/.axelar ~/.axelar_mainnet_backup"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"cp -r ~/.axelar_testnet ~/.axelar_testnet_backup"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"cp -r ~/.axelar_testnet-2 ~/.axelar_testnet-2_backup"}
+</CodeBlock>
+}
 ]} />
 
 ## Resume your Axelar node
@@ -53,18 +59,24 @@ Resume your stopped Axelar node.
 </Callout>
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n mainnet"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n mainnet"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n testnet-2"}
+</CodeBlock>
+}
 ]} />
 
 ## Learn your address
@@ -76,18 +88,24 @@ Resume your stopped Axelar node.
 Learn the address of your `validator` account:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard keys show validator -a --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard keys show validator -a --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard keys show validator -a --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard keys show validator -a --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard keys show validator -a --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 ## Check your AXL balance
@@ -99,39 +117,51 @@ Let `{MY_ADDRESS}` denote the address of your `validator` account.
 </Callout>
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard q bank balances {MY_ADDRESS} --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard q bank balances {MY_ADDRESS} --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard q bank balances {MY_ADDRESS} --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard q bank balances {MY_ADDRESS} --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard q bank balances {MY_ADDRESS} --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 If this is a new account then you should see no token balances.
 
-<Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <Markdown>
-      {""}
-    </Markdown>
-  },
-  {
-    title: "Testnet",
-    content: <Markdown>{`
 ## Get AXL tokens from the faucet
+
+<Tabs tabs={[
+{
+title: "Mainnet",
+content: <Markdown>
+{"There is no faucet for mainnet AXL tokens."}
+</Markdown>
+},
+{
+title: "Testnet",
+content: <Markdown>{`
 
 Get free AXL testnet tokens sent to {MY_ADDRESS} from the [Axelar Testnet Faucet](https://faucet.testnet.axelar.dev/).
 
 Check your balance again to see the tokens you received from the faucet.
-    `}</Markdown>
-  }
+`}</Markdown> }, { title: "Testnet-2", content: <Markdown>{`
+
+Get free AXL testnet tokens sent to {MY_ADDRESS} from the [Axelar Testnet Faucet](https://faucet-casablanca.testnet.axelar.dev/).
+
+Check your balance again to see the tokens you received from the faucet.
+`}</Markdown>
+}
 ]} />
 
 ## Recover your secret keys

--- a/pages/node/join-genesis.md
+++ b/pages/node/join-genesis.md
@@ -44,26 +44,37 @@ cd axelarate-community
 ```
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <div>
-      Launch a new Axelar mainnet node with version <Markdown>`0.10.7`</Markdown> of axelar-core:
-      <CodeBlock language="bash">
-        {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.10.7 -n mainnet"}
-      </CodeBlock>
-      Your Axelar node will initialize your data folder <Markdown>`~/.axelar`</Markdown>
-    </div>
-  },
-  {
-    title: "Testnet",
-    content: <div>
-      Launch a new Axelar testnet node with version `0.13.6` of axelar-core:
-      <CodeBlock language="bash">
-        KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.13.6
-      </CodeBlock>
-      Your Axelar node will initialize your data folder `~/.axelar_testnet`
-    </div>
-  }
+{
+title: "Mainnet",
+content: <div>
+Launch a new Axelar mainnet node with version <Markdown>`0.10.7`</Markdown> of axelar-core:
+<CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.10.7 -n mainnet"}
+</CodeBlock>
+Your Axelar node will initialize your data folder <Markdown>`~/.axelar`</Markdown>
+
+</div>
+},
+{
+title: "Testnet",
+content: <div>
+Launch a new Axelar testnet node with version `0.13.6` of axelar-core:
+<CodeBlock language="bash">
+KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.13.6
+</CodeBlock>
+Your Axelar node will initialize your data folder `~/.axelar_testnet`
+</div>
+},
+{
+title: "Testnet-2",
+content: <div>
+Launch a new Axelar testnet node with version `0.17.0` of axelar-core:
+<CodeBlock language="bash">
+KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.17.0
+</CodeBlock>
+Your Axelar node will initialize your data folder `~/.axelar_testnet-2`
+</div>
+}
 ]} />
 
 To recover your secret keys from mnemonics, use `-t path_to_tendermint_key -m path_to_validator_mnemonic -r` (`-r` is to reset the chain). These flags work only on a completely fresh state.
@@ -75,35 +86,47 @@ Your Axelar node will launch and begin downloading the blockchain.
 BACKUP and DELETE the `validator` account secret mnemonic:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/validator.txt"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/validator.txt"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/validator.txt"}
+</CodeBlock>
+}
 ]} />
 
 BACKUP but do NOT DELETE the Tendermint consensus secret key (this is needed on node restarts):
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/.core/config/priv_validator_key.json"}
+</CodeBlock>
+}
 ]} />
 
 ## View logs
@@ -113,18 +136,24 @@ View the streaming logs for your Axelar node:
 In a new terminal window:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"tail -f ~/.axelar/logs/axelard.log"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"tail -f ~/.axelar_testnet/logs/axelard.log"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar/logs/axelard.log"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar_testnet/logs/axelard.log"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar_testnet-2/logs/axelard.log"}
+</CodeBlock>
+}
 ]} />
 
 ## Follow the upgrade path
@@ -132,14 +161,18 @@ In a new terminal window:
 Your Axelar node will download the blockchain until it reaches the first `UPGRADE_HEIGHT` listed below.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <MarkdownPath src="/md/mainnet/upgrade-path.md" />
-  },
-  {
-    title: "Testnet",
-    content: <MarkdownPath src="/md/testnet/upgrade-path.md" />
-  }
+{
+title: "Mainnet",
+content: <MarkdownPath src="/md/mainnet/upgrade-path.md" />
+},
+{
+title: "Testnet",
+content: <MarkdownPath src="/md/testnet/upgrade-path.md" />
+},
+{
+title: "Testnet-2",
+content: <MarkdownPath src="/md/testnet-2/upgrade-path.md" />
+}
 ]} />
 
 After your blockchain has reached `UPGRADE_HEIGHT` you will see a panic in the logs like
@@ -151,18 +184,24 @@ panic: UPGRADE {NAME} NEEDED at height: {UPGRADE_HEIGHT}:
 Launch your Axelar node again with the `CORE_VERSION` listed below:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a {CORE_VERSION} -n mainnet"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a {CORE_VERSION} -n testnet"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a {CORE_VERSION} -n mainnet"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a {CORE_VERSION} -n testnet"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a {CORE_VERSION} -n testnet-2"}
+</CodeBlock>
+}
 ]} />
 
 Your Axelar node will launch and resume downloading the blockchain.
@@ -191,4 +230,3 @@ Congratulations! You joined the Axelar network and downloaded the blockchain.
 Learn what you can do with Axelar:
 
 - [Basic node management](./basic)
-- Tutorial: transfer UST or LUNA tokens from the Terra blockchain to EVM-compatible blockchains such as Avalanche, Ethereum, Fantom, Moonbeam, Polygon.

--- a/pages/node/join.md
+++ b/pages/node/join.md
@@ -44,26 +44,37 @@ cd axelarate-community
 ```
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <div>
-      Launch a new Axelar mainnet node with version <Markdown>`0.10.7`</Markdown> of axelar-core:
-      <CodeBlock language="bash">
-        {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.10.7 -n mainnet"}
-      </CodeBlock>
-      Your Axelar node will initialize your data folder <Markdown>`~/.axelar`</Markdown>
-    </div>
-  },
-  {
-    title: "Testnet",
-    content: <div>
-      Launch a new Axelar testnet node with version <Markdown>`0.13.6`</Markdown> of axelar-core:
-      <CodeBlock language="bash">
-        {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.13.6"}
-      </CodeBlock>
-      Your Axelar node will initialize your data folder <Markdown>`~/.axelar_testnet`</Markdown>
-    </div>
-  }
+{
+title: "Mainnet",
+content: <div>
+Launch a new Axelar mainnet node with version <Markdown>`0.10.7`</Markdown> of axelar-core:
+<CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.10.7 -n mainnet"}
+</CodeBlock>
+Your Axelar node will initialize your data folder <Markdown>`~/.axelar`</Markdown>
+
+</div>
+},
+{
+title: "Testnet",
+content: <div>
+Launch a new Axelar testnet node with version <Markdown>`0.13.6`</Markdown> of axelar-core:
+<CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.13.6"}
+</CodeBlock>
+Your Axelar node will initialize your data folder <Markdown>`~/.axelar_testnet`</Markdown>
+</div>
+},
+{
+title: "Testnet-2",
+content: <div>
+Launch a new Axelar testnet node with version <Markdown>`0.17.0`</Markdown> of axelar-core:
+<CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -a v0.17.0 -n testnet-2"}
+</CodeBlock>
+Your Axelar node will initialize your data folder <Markdown>`~/.axelar_testnet-2`</Markdown>
+</div>
+}
 ]} />
 
 To recover your secret keys from mnemonics, use `-t path_to_tendermint_key -m path_to_validator_mnemonic -r` (`-r` is to reset the chain). These flags work only on a completely fresh state.
@@ -75,35 +86,47 @@ Then your Axelar node will begin downloading blocks in the blockchain one-by-one
 BACKUP and DELETE the `validator` account secret mnemonic:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/validator.txt"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/validator.txt"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/validator.txt"}
+</CodeBlock>
+}
 ]} />
 
 BACKUP but do NOT DELETE the Tendermint consensus secret key (this is needed on node restarts):
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/.core/config/priv_validator_key.json"}
+</CodeBlock>
+}
 ]} />
 
 ## View logs
@@ -113,18 +136,24 @@ View the streaming logs for your Axelar node:
 In a new terminal window:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"tail -f ~/.axelar/logs/axelard.log"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"tail -f ~/.axelar_testnet/logs/axelard.log"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar/logs/axelard.log"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar_testnet/logs/axelard.log"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"tail -f ~/.axelar_testnet-2/logs/axelard.log"}
+</CodeBlock>
+}
 ]} />
 
 You should see log messages for each block in the blockchain that your node downloads.
@@ -142,18 +171,24 @@ kill -9 $(pgrep -f "axelard start")
 Delete your `data` directory:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"rm -r ~/.axelar/.core/data"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"rm -r ~/.axelar_testnet/.core/data"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"rm -r ~/.axelar/.core/data"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"rm -r ~/.axelar_testnet/.core/data"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"rm -r ~/.axelar_testnet-2/.core/data"}
+</CodeBlock>
+}
 ]} />
 
 # Download the latest Axelar blockchain snapshot
@@ -173,18 +208,24 @@ Let `{SNAPSHOT_FILE}` denote the file name of the snapshot you downloaded. Examp
 Decompress the downloaded snapshot into your `data` directory:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"lz4 -dc --no-sparse {SNAPSHOT_FILE} | tar xfC - ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"lz4 -dc --no-sparse {SNAPSHOT_FILE} | tar xfC - ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"lz4 -dc --no-sparse {SNAPSHOT_FILE} | tar xfC - ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"lz4 -dc --no-sparse {SNAPSHOT_FILE} | tar xfC - ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"lz4 -dc --no-sparse {SNAPSHOT_FILE} | tar xfC - ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 ## Resume your node
@@ -192,18 +233,24 @@ Decompress the downloaded snapshot into your `data` directory:
 Resume your Axelar node with the latest version of axelar-core:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n mainnet"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n testnet"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n mainnet"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n testnet"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n testnet-2"}
+</CodeBlock>
+}
 ]} />
 
 Your Axelar node will launch and resume downloading the blockchain. You should see log messages for new blocks.
@@ -230,4 +277,3 @@ Congratulations! You joined the Axelar network and downloaded the blockchain.
 Learn what you can do with Axelar:
 
 - [Basic node management](./basic)
-- Tutorial: transfer UST or LUNA tokens from the Terra blockchain to EVM-compatible blockchains such as Avalanche, Ethereum, Fantom, Moonbeam, Polygon.

--- a/pages/validator/external-chains/overview.md
+++ b/pages/validator/external-chains/overview.md
@@ -175,4 +175,5 @@ The Axelar consensus protocol simply ignores all votes for chain C events from t
 - Your broadcaster account will lose funds because the Axelar network does not refund transaction fees for vote messages unless you are a registered maintainer for chain C.
 - You will see spurious error messages in your vald logs.
 - Axelar dashboards might display your votes for chain C even though you are not a registered maintainer for C.
-  </Callout>
+
+</Callout>

--- a/pages/validator/external-chains/overview.md
+++ b/pages/validator/external-chains/overview.md
@@ -100,18 +100,24 @@ kill -9 $(pgrep -f "axelard vald-start")
 Immediately resume your companion processes `vald`, `tofnd`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n mainnet"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n mainnet"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n testnet-2"}
+</CodeBlock>
+}
 ]} />
 
 ## Check your connections to new chains in vald
@@ -135,32 +141,38 @@ For each external blockchain you selected earlier you must inform the Axelar net
 Example: multiple EVM chains in one command:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx nexus register-chain-maintainer avalanche ethereum fantom moonbeam polygon --from broadcaster --chain-id axelar-dojo-1 --home ~/.axelar/.vald --gas auto --gas-adjustment 1.5"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx nexus register-chain-maintainer avalanche ethereum fantom moonbeam polygon --from broadcaster --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.vald --gas auto --gas-adjustment 1.5"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx nexus register-chain-maintainer avalanche ethereum fantom moonbeam polygon --from broadcaster --chain-id axelar-dojo-1 --home ~/.axelar/.vald --gas auto --gas-adjustment 1.5"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx nexus register-chain-maintainer avalanche ethereum fantom moonbeam polygon --from broadcaster --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.vald --gas auto --gas-adjustment 1.5"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx nexus register-chain-maintainer avalanche ethereum fantom moonbeam polygon --from broadcaster --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.vald --gas auto --gas-adjustment 1.5"}
+</CodeBlock>
+}
 ]} />
 
 <Callout emoji="ℹ️">
   Validator voting for maintained chains
 
-  If you have added an RPC endpoint to your configuration for chain C then your validator will _always_ post vote messages for chain C on the Axelar network, regardless of whether you are registered as a maintainer for chain C. (Why? Because the `vald` process that posts vote messages is stateless; it doesn't know whether your validator is registered as a maintainer for chain C.)
+If you have added an RPC endpoint to your configuration for chain C then your validator will _always_ post vote messages for chain C on the Axelar network, regardless of whether you are registered as a maintainer for chain C. (Why? Because the `vald` process that posts vote messages is stateless; it doesn't know whether your validator is registered as a maintainer for chain C.)
 
-  The Axelar consensus protocol simply ignores all votes for chain C events from those validators who are not registered as a maintainer for C.
+The Axelar consensus protocol simply ignores all votes for chain C events from those validators who are not registered as a maintainer for C.
 </Callout>
 
 <Callout type="warning" emoji="⚠️">
   Caution: If for some reason you need to deregister as chain maintainer for a chain C then you should also disable the RPC endpoint for C (set `start-with-bridge = false` in your `config.toml` file) and then restart vald. Otherwise, your validator will continue to post vote messages for chain C on the Axelar network, leading to the following consequences:
 
-  - Your broadcaster account will lose funds because the Axelar network does not refund transaction fees for vote messages unless you are a registered maintainer for chain C.
-  - You will see spurious error messages in your vald logs.
-  - Axelar dashboards might display your votes for chain C even though you are not a registered maintainer for C.
-</Callout>
+- Your broadcaster account will lose funds because the Axelar network does not refund transaction fees for vote messages unless you are a registered maintainer for chain C.
+- You will see spurious error messages in your vald logs.
+- Axelar dashboards might display your votes for chain C even though you are not a registered maintainer for C.
+  </Callout>

--- a/pages/validator/setup/backup.md
+++ b/pages/validator/setup/backup.md
@@ -27,18 +27,24 @@ Items 3 and 4 were created when you completed [Launch validator companion proces
 BACKUP and DELETE the `validator` account secret mnemonic:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/validator.txt"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/validator.txt"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/validator.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/validator.txt"}
+</CodeBlock>
+}
 ]} />
 
 ## Tendermint validator secret key
@@ -46,18 +52,24 @@ BACKUP and DELETE the `validator` account secret mnemonic:
 BACKUP but do NOT DELETE the Tendermint consensus secret key (this is needed on node restarts):
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/.core/config/priv_validator_key.json"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/.core/config/priv_validator_key.json"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/.core/config/priv_validator_key.json"}
+</CodeBlock>
+}
 ]} />
 
 ## Broadcaster account secret mnemonic
@@ -65,18 +77,24 @@ BACKUP but do NOT DELETE the Tendermint consensus secret key (this is needed on 
 BACKUP and DELETE the `broadcaster` account secret mnemonic:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/broadcaster.txt"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/broadcaster.txt"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/broadcaster.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/broadcaster.txt"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/broadcaster.txt"}
+</CodeBlock>
+}
 ]} />
 
 ## Tofnd secret mnemonic
@@ -84,16 +102,22 @@ BACKUP and DELETE the `broadcaster` account secret mnemonic:
 BACKUP and DELETE the `tofnd` secret mnemonic:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/.tofnd/import"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/.tofnd/import"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/.tofnd/import"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/.tofnd/import"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/.tofnd/import"}
+</CodeBlock>
+}
 ]} />

--- a/pages/validator/setup/health-check.md
+++ b/pages/validator/setup/health-check.md
@@ -7,25 +7,31 @@ import CodeBlock from '../../../components/code-block'
 
 Check the status of your validator.
 
-* tofnd check: `tofnd` companion process is alive and accessible from `vald`.
-* broadcaster check: Your `broadcaster` address is registered and has balance at least 5 AXL.
-* operator check: Your valoper address is indeed an Axelar validator in good status. (Possible bad status includes: not in active set, missed too many blocks, jail status, etc.)
+- tofnd check: `tofnd` companion process is alive and accessible from `vald`.
+- broadcaster check: Your `broadcaster` address is registered and has balance at least 5 AXL.
+- operator check: Your valoper address is indeed an Axelar validator in good status. (Possible bad status includes: not in active set, missed too many blocks, jail status, etc.)
 
 This step is not mandatory but it is good practice to help you detect and diagnose problems with your validator.
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard health-check --tofnd-host localhost --operator-addr {VALOPER_ADDR} --home ~/.axelar/.vald"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard health-check --tofnd-host localhost --operator-addr {VALOPER_ADDR} --home ~/.axelar_testnet/.vald"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard health-check --tofnd-host localhost --operator-addr {VALOPER_ADDR} --home ~/.axelar/.vald"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard health-check --tofnd-host localhost --operator-addr {VALOPER_ADDR} --home ~/.axelar_testnet/.vald"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard health-check --tofnd-host localhost --operator-addr {VALOPER_ADDR} --home ~/.axelar_testnet-2/.vald"}
+</CodeBlock>
+}
 ]} />
 
 You should see output like:
@@ -39,5 +45,5 @@ operator check: passed
 <Callout emoji="💡">
   Tip: If you do `axelard health-check` within 50 blocks after first becoming a validator then your validator will not yet post a `heartbeat` transaction.
 
-  In this case, your heath check might return `stale_tss_heartbeat`.  Wait 50 blocks for your validator to automatically post a heartbeat transaction and then try `health-check` again.
+In this case, your heath check might return `stale_tss_heartbeat`. Wait 50 blocks for your validator to automatically post a heartbeat transaction and then try `health-check` again.
 </Callout>

--- a/pages/validator/setup/manual.md
+++ b/pages/validator/setup/manual.md
@@ -49,18 +49,24 @@ Your `tofnd` secret mnemonic is in a file `.tofnd/export`. Save this mnemonic so
 ## Set environment variables
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo export CHAIN_ID=axelar-dojo-1 >> $HOME/.profile"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo export CHAIN_ID=axelar-testnet-lisbon-3 >> $HOME/.profile"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo export CHAIN_ID=axelar-dojo-1 >> $HOME/.profile"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo export CHAIN_ID=axelar-testnet-lisbon-3 >> $HOME/.profile"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo export CHAIN_ID=axelar-testnet-casablanca-1 >> $HOME/.profile"}
+</CodeBlock>
+}
 ]} />
 
 ```bash
@@ -91,10 +97,12 @@ source $HOME/.profile
 
 Initialize your Axelar node, fetch configuration, genesis, seeds.
 
+TODO FIX
+
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`axelard init $MONIKER --chain-id $CHAIN_ID
 wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/config.toml -O $HOME/.axelar/config/config.toml
 wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/app.toml -O $HOME/.axelar/config/app.toml
@@ -102,55 +110,46 @@ wget https://axelar-mainnet.s3.us-east-2.amazonaws.com/genesis.json -O $HOME/.ax
 wget https://axelar-mainnet.s3.us-east-2.amazonaws.com/seeds.txt -O $HOME/.axelar/config/seeds.txt
 
 # enter seeds to your config.json file
+
 sed -i.bak 's/seeds = \"\"/seeds = \"'$(cat $HOME/.axelar/config/seeds.txt)'\"/g' $HOME/.axelar/config/config.toml
 
 # set external ip to your config.json file
-sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-{`axelard init $MONIKER --chain-id $CHAIN_ID
+
+sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`} </CodeBlock> }, { title: "Testnet", content: <CodeBlock language="bash"> {`axelard init $MONIKER --chain-id $CHAIN_ID
 wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/config.toml -O $HOME/.axelar/config/config.toml
 wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/app.toml -O $HOME/.axelar/config/app.toml
 wget https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -O $HOME/.axelar/config/genesis.json
 wget https://axelar-testnet.s3.us-east-2.amazonaws.com/seeds.txt -O $HOME/.axelar/config/seeds.txt
 
 # enter seeds to your config.json file
+
 sed -i.bak 's/seeds = \"\"/seeds = \"'$(cat $HOME/.axelar/config/seeds.txt)'\"/g' $HOME/.axelar/config/config.toml
 
 # set external ip to your config.json file
+
 sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`}
-    </CodeBlock>
-  }
+</CodeBlock>
+}
 ]} />
 
 ## Sync From Snapshot
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-{`axelard unsafe-reset-all
-URL=\`curl https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelar-dojo-1-pruned")|.url'\`
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{`axelard unsafe-reset-all URL=\`curl https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelar-dojo-1-pruned")|.url'\`
 echo $URL
 cd $HOME/.axelar/
 wget -O - $URL | lz4 -d | tar -xvf -
-cd $HOME`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-{`axelard unsafe-reset-all
+cd $HOME`} </CodeBlock> }, { title: "Testnet", content: <CodeBlock language="bash"> {`axelard unsafe-reset-all
 URL=\`curl https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'\`
 echo $URL
 cd $HOME/.axelar/
 wget -O - $URL | lz4 -d | tar -xvf -
 cd $HOME`}
-    </CodeBlock>
-  }
+</CodeBlock>
+}
 ]} />
 
 ## Create services

--- a/pages/validator/setup/manual.md
+++ b/pages/validator/setup/manual.md
@@ -97,8 +97,6 @@ source $HOME/.profile
 
 Initialize your Axelar node, fetch configuration, genesis, seeds.
 
-TODO FIX
-
 <Tabs tabs={[
 {
 title: "Mainnet",
@@ -115,21 +113,7 @@ sed -i.bak 's/seeds = \"\"/seeds = \"'$(cat $HOME/.axelar/config/seeds.txt)'\"/g
 
 # set external ip to your config.json file
 
-sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`} </CodeBlock> }, { title: "Testnet", content: <CodeBlock language="bash"> {`axelard init $MONIKER --chain-id $CHAIN_ID
-wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/config.toml -O $HOME/.axelar/config/config.toml
-wget https://raw.githubusercontent.com/axelarnetwork/axelarate-community/main/configuration/app.toml -O $HOME/.axelar/config/app.toml
-wget https://axelar-testnet.s3.us-east-2.amazonaws.com/genesis.json -O $HOME/.axelar/config/genesis.json
-wget https://axelar-testnet.s3.us-east-2.amazonaws.com/seeds.txt -O $HOME/.axelar/config/seeds.txt
-
-# enter seeds to your config.json file
-
-sed -i.bak 's/seeds = \"\"/seeds = \"'$(cat $HOME/.axelar/config/seeds.txt)'\"/g' $HOME/.axelar/config/config.toml
-
-# set external ip to your config.json file
-
-sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`}
-</CodeBlock>
-}
+sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.co)"':26656\"/g' $HOME/.axelar/config/config.toml`} </CodeBlock> }
 ]} />
 
 ## Sync From Snapshot
@@ -142,14 +126,7 @@ content: <CodeBlock language="bash">
 echo $URL
 cd $HOME/.axelar/
 wget -O - $URL | lz4 -d | tar -xvf -
-cd $HOME`} </CodeBlock> }, { title: "Testnet", content: <CodeBlock language="bash"> {`axelard unsafe-reset-all
-URL=\`curl https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'\`
-echo $URL
-cd $HOME/.axelar/
-wget -O - $URL | lz4 -d | tar -xvf -
-cd $HOME`}
-</CodeBlock>
-}
+cd $HOME`} </CodeBlock> }
 ]} />
 
 ## Create services

--- a/pages/validator/setup/register-broadcaster.md
+++ b/pages/validator/setup/register-broadcaster.md
@@ -16,18 +16,24 @@ Axelar validators exchange messages with one another via the Axelar blockchain. 
 Your `broadcaster` address `{BROADCASTER_ADDR}` is stored in a text file:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock>
-      {"~/.axelar/broadcaster.address"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock>
-      {"~/.axelar_testnet/broadcaster.address"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock>
+{"~/.axelar/broadcaster.address"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock>
+{"~/.axelar_testnet/broadcaster.address"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock>
+{"~/.axelar_testnet-2/broadcaster.address"}
+</CodeBlock>
+}
 ]} />
 
 ## Fund your validator and broadcaster accounts
@@ -38,18 +44,24 @@ Go to [Axelar faucet](http://faucet.testnet.axelar.dev/) and send some free AXL 
 ## Register your broadcaster account
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx snapshot register-proxy {BROADCASTER_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx snapshot register-proxy {BROADCASTER_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx snapshot register-proxy {BROADCASTER_ADDR} --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx snapshot register-proxy {BROADCASTER_ADDR} --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx snapshot register-proxy {BROADCASTER_ADDR} --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 ## Optional: check your broadcaster registration

--- a/pages/validator/setup/stake-axl.md
+++ b/pages/validator/setup/stake-axl.md
@@ -9,27 +9,33 @@ Stake AXL tokens on the Axelar network.
 
 Choose an amount `{STAKE_AMOUNT}` of AXL tokens you wish to stake. `{STAKE_AMOUNT}` is denominated in `uaxl` where `1 AXL = 1000000 uaxl`.
 
-* You need at least 1 AXL to participate in consensus on the Axelar network
-* You need enough stake to get into the "active set" of size 50: if 50 or more other validators have more stake than you then you cannot participate in consensus.
-* Optional: you need at least 2% of total bonded stake to participate in multi-party cryptography protocols with other validators.
+- You need at least 1 AXL to participate in consensus on the Axelar network
+- You need enough stake to get into the "active set" of size 50: if 50 or more other validators have more stake than you then you cannot participate in consensus.
+- Optional: you need at least 2% of total bonded stake to participate in multi-party cryptography protocols with other validators.
 
 Choose a moniker `{MY_MONIKER}` for your validator. There are many other parameters you may choose for your validator. For simplicity these instructions specify default values for all other parameters.
 
 Make your `validator` account into an Axelar validator by staking AXL tokens:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar/bin/axelard tx staking create-validator --amount {STAKE_AMOUNT}uaxl --moniker "{MY_MONIKER}" --commission-rate="0.10" --commission-max-rate="0.20" --commission-max-change-rate="0.01" --min-self-delegation="1" --pubkey="$(~/.axelar/bin/axelard tendermint show-validator --home ~/.axelar/.core)" --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`echo my-secret-password | ~/.axelar_testnet/bin/axelard tx staking create-validator --amount {STAKE_AMOUNT}uaxl --moniker "{MY_MONIKER}" --commission-rate="0.10" --commission-max-rate="0.20" --commission-max-change-rate="0.01" --min-self-delegation="1" --pubkey="$(~/.axelar_testnet/bin/axelard tendermint show-validator --home ~/.axelar_testnet/.core)" --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx staking create-validator --amount {STAKE_AMOUNT}uaxl --moniker "{MY_MONIKER}" --commission-rate="0.10" --commission-max-rate="0.20" --commission-max-change-rate="0.01" --min-self-delegation="1" --pubkey="$(~/.axelar_testnet-2/bin/axelard tendermint show-validator --home ~/.axelar_testnet-2/.core)" --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core`}
+</CodeBlock>
+}
 ]} />
 
 ## Optional: Learn your valoper address
@@ -39,50 +45,68 @@ Make your `validator` account into an Axelar validator by staking AXL tokens:
 Learn the `{VALOPER_ADDR}` address associated with your `validator` account
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard keys show validator -a --bech val --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard keys show validator -a --bech val --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard keys show validator -a --bech val --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard keys show validator -a --bech val --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard keys show validator -a --bech val --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />
 
 ## Optional: check the stake amount delegated to your validator
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar/bin/axelard q staking validator {VALOPER_ADDR} | grep tokens"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"~/.axelar_testnet/bin/axelard q staking validator {VALOPER_ADDR} | grep tokens"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"~/.axelar/bin/axelard q staking validator {VALOPER_ADDR} | grep tokens"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet/bin/axelard q staking validator {VALOPER_ADDR} | grep tokens"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"~/.axelar_testnet-2/bin/axelard q staking validator {VALOPER_ADDR} | grep tokens"}
+</CodeBlock>
+}
 ]} />
 
 ## Optional: delegate additional stake to your validator
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar/bin/axelard tx staking delegate {VALOPER_ADDR} {STAKE_AMOUNT}uaxl --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx staking delegate {VALOPER_ADDR} {STAKE_AMOUNT}uaxl --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar/bin/axelard tx staking delegate {VALOPER_ADDR} {STAKE_AMOUNT}uaxl --from validator --chain-id axelar-dojo-1 --home ~/.axelar/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet/bin/axelard tx staking delegate {VALOPER_ADDR} {STAKE_AMOUNT}uaxl --from validator --chain-id axelar-testnet-lisbon-3 --home ~/.axelar_testnet/.core"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"echo my-secret-password | ~/.axelar_testnet-2/bin/axelard tx staking delegate {VALOPER_ADDR} {STAKE_AMOUNT}uaxl --from validator --chain-id axelar-testnet-casablanca-1 --home ~/.axelar_testnet-2/.core"}
+</CodeBlock>
+}
 ]} />

--- a/pages/validator/setup/vald-tofnd.md
+++ b/pages/validator/setup/vald-tofnd.md
@@ -24,18 +24,24 @@ In what follows you will execute a shell script to launch the companion processe
 Launch `vald`, `tofnd` for the first time:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n mainnet"}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
-      {"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh"}
-    </CodeBlock>
-  }
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n mainnet"}
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh"}
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{"KEYRING_PASSWORD=my-secret-password TOFND_PASSWORD=my-tofnd-password ./scripts/validator-tools-host.sh -n testnet-2"}
+</CodeBlock>
+}
 ]} />
 
 To recover your secret keys from mnemonics, use `-p path_to_broadcaster_mnemonic -z path_to_tofnd_mnemonic`. These flags work only on a completely fresh state.
@@ -49,18 +55,25 @@ To recover your secret keys from mnemonics, use `-p path_to_broadcaster_mnemonic
 View the streaming logs for `vald`, `tofnd`:
 
 <Tabs tabs={[
-  {
-    title: "Mainnet",
-    content: <CodeBlock language="bash">
+{
+title: "Mainnet",
+content: <CodeBlock language="bash">
 {`tail -f ~/.axelar/logs/vald.log
 tail -f ~/.axelar/logs/tofnd.log`}
-    </CodeBlock>
-  },
-  {
-    title: "Testnet",
-    content: <CodeBlock language="bash">
+</CodeBlock>
+},
+{
+title: "Testnet",
+content: <CodeBlock language="bash">
 {`tail -f ~/.axelar_testnet/logs/vald.log
 tail -f ~/.axelar_testnet/logs/tofnd.log`}
-    </CodeBlock>
-  }
+</CodeBlock>
+},
+{
+title: "Testnet-2",
+content: <CodeBlock language="bash">
+{`tail -f ~/.axelar_testnet-2/logs/vald.log
+tail -f ~/.axelar_testnet-2/logs/tofnd.log`}
+</CodeBlock>
+}
 ]} />

--- a/public/md/testnet-2/upgrade-path.md
+++ b/public/md/testnet-2/upgrade-path.md
@@ -1,0 +1,3 @@
+| Core Version | Start Height | Upgrade Height |
+| ------------ | ------------ | -------------- |
+| v0.17.0      | 0            | N/A            |


### PR DESCRIPTION
- We should refactor docs code so that tabs set only a variable for things like a path `~/.axelar_testnet-2` or chain-id `axelar-testnet-casablanca-1` so that we don't duplicate every CLI command x times for x networks.
- Some broken docs code removed in https://github.com/axelarnetwork/axelar-docs/commit/016f818fdf5a818406cf0afb4855de8ffe371db9 .  That page needs to be reworked anyway so not worth the time to figure out how to fix it.