### PR TITLE
fix: fees wording

### DIFF
--- a/pages/controller.md
+++ b/pages/controller.md
@@ -13,10 +13,10 @@ A _controller_ is a special Axelar account with privileges to execute certain `a
 <Callout emoji="📝">
   Most participants do not need this information
 
-  Most Axelar roles (end user, node operator, validator, etc) do not need the information in this article. Many CLI commands in this article can be executed only from a controller account on Axelar network.
+Most Axelar roles (end user, node operator, validator, etc) do not need the information in this article. Many CLI commands in this article can be executed only from a controller account on Axelar network.
 </Callout>
 
 ## Prerequisites
 
-- Your fully-synced Axelar node has an account you control named `controller`. You might also have an account named `validator`. All accounts have enough AXL tokens to pay transaction fees for Axelar network.
+- Your fully-synced Axelar node has an account you control named `controller`. You might also have an account named `validator`. All accounts have enough AXL tokens to pay relayer gas fees for Axelar network.
 - Your `controller` account is a registered controller on the Axelar network.

--- a/pages/dev/gas-receiver.md
+++ b/pages/dev/gas-receiver.md
@@ -3,9 +3,11 @@
 General Message Passing is a two-step process:
 
 1. **_Approval._** Axelar validators approve a message via vote on the message payload hash.
-2. **_Execution._** Anyone can execute an approved message by posting the payload hash preimage to the destination chain and paying transaction fees.
+2. **_Execution._** Anyone can execute an approved message by posting the payload hash preimage to the destination chain and paying relayer gas fees.
 
-The Axelar network provides approval but not execution. Axelar also provides an optional relayer service called _gas receiver_ that provides execution of approved messages. Anyone can use the gas receiver service by pre-paying the transaction fee on the source chain. Axelar relayer services observe use of the gas receiver for a given message and automatically execute the General Message Passing call.
+The Axelar network provides approval but not execution. Axelar also provides an optional relayer service called _gas receiver_ that provides execution of approved messages. Anyone can use the gas receiver service by pre-paying the relayer gas fee on the source chain. Axelar relayer services observe use of the gas receiver for a given message and automatically execute the General Message Passing call.
+
+Relayer gas fees are needed only to pay gas costs across chains.
 
 ## Introduction
 

--- a/pages/resources/mainnet.md
+++ b/pages/resources/mainnet.md
@@ -1,5 +1,6 @@
 # Mainnet
 
+import Callout from 'nextra-theme-docs/callout'
 import MarkdownPath from '../../components/markdown'
 import EVMChains from '../../components/evm/chains'
 import EVMAssets from '../../components/evm/assets'
@@ -9,7 +10,7 @@ import IBCChannels from '../../components/ibc/channels'
 | --------------------- | --------- |
 | `axelar-core` version | `v0.17.1` |
 | `vald` version        | `v0.17.0` |
-| `tofnd` version       | `v0.10.1`  |
+| `tofnd` version       | `v0.10.1` |
 
 <div className="space-y-1 mt-4">
   ## EVM Chains
@@ -26,52 +27,58 @@ import IBCChannels from '../../components/ibc/channels'
   <IBCChannels environment="mainnet" />
 </div>
 
-## Cross-chain transfer fee
+## Cross-chain relayer gas fee
 
-The Network (and thus the Satellite app) charges a base fee for all cross-chain transfers.
-Most up-to-date values are present in the Satellite app.
-This fee only depends on the source/destination chain and the asset and does NOT take a percentage from the transfer amount.
-When transferring an asset X from chain Y to chain Z, the transfer fee is the sum of per-chain fee for that asset.
-For e.g. a transfer of 1000 USDC from Ethereum to Osmosis will have a fee of 40.5 USDC (= 40 USDC for Ethereum + 0.5 USDC for Osmosis),
-and so the recipient will get 959.5 USDC.
+The Axelar network charges a _relayer gas fee_ for all cross-chain token transfers in order to pay for network-level transaction ("gas") fees across chains.
+The relayer gas fee amount depends only on:
+
+- the asset
+- the source chain
+- the destination chain
+
+<Callout emoji="💡">
+  The relayer gas fee does NOT take a percentage from the transfer amount.
+</Callout>
+
+Example: a transfer of X USDC tokens from Ethereum to Osmosis will have a fee of 40.5 USDC (= 40 USDC for Ethereum + 0.5 USDC for Osmosis),
+and so the recipient will get X - 40.5 USDC tokens on Osmosis.
 
 | Asset symbol | Ethereum   | non-Ethereum EVM | Cosmos Chains | Decimals | Unit         |
 | ------------ | ---------- | ---------------- | ------------- | -------- | ------------ |
-| USDC         | 40 USDC    | 1 USDC           | 0.5 USDC      | 6        | uusdc        |
+| USDC         | 60 USDC    | 1 USDC           | 0.5 USDC      | 6        | uusdc        |
 | WETH         | 0.02 WETH  | N/A              | 0.0002 WETH   | 18       | weth-wei     |
 | WBTC         | 0.002 WBTC | N/A              | 0.00002 WBTC  | 8        | wbtc-satoshi |
-| DAI          | 40 DAI     | 1 DAI            | 0.5 DAI       | 18       | dai-wei      |
-| FRAX         | 40 FRAX    | 1 FRAX           | 0.5 FRAX      | 18       | frax-wei     |
-| USDT         | 40 USDT    | 1 USDT           | 0.5 USDT      | 6        | uusdt        |
+| DAI          | 60 DAI     | 1 DAI            | 0.5 DAI       | 18       | dai-wei      |
+| FRAX         | 60 FRAX    | 1 FRAX           | 0.5 FRAX      | 18       | frax-wei     |
+| USDT         | 60 USDT    | 1 USDT           | 0.5 USDT      | 6        | uusdt        |
 | ATOM         | 4 ATOM     | 0.1 ATOM         | 0.05 ATOM     | 6        | uatom        |
 | UST          | 80 UST     | 2 UST            | 1 UST         | 6        | uusd         |
 | LUNA         | 40 LUNA    | 1 LUNA           | 0.5 LUNA      | 6        | uluna        |
-| NGM          | 40 NGM     | 1 NGM            | 0.5 NGM       | 6        | ungm         |
-| EEUR         | 40 EEUR    | 1 EEUR           | 0.5 EEUR      | 6        | eeur         |
+| NGM          | 60 NGM     | 1 NGM            | 0.5 NGM       | 6        | ungm         |
+| EEUR         | 60 EEUR    | 1 EEUR           | 0.5 EEUR      | 6        | eeur         |
 
-The current transfer fee can also be queried on the network with
+The current gas relayer fee is also available via node query:
 
 ```bash
 axelard q nexus transfer-fee [source chain] [destination chain] [amount]
 ```
 
-For e.g., querying the example transfer above (note `1 UST = 10^6 uusd`),
+Example: transfer USDC from Ethereum to Osmosis. (The amount here is arbitrary---gas relayer fees do not depend on the amount. `1 USDC = 10^6 uusdc`).
 
 ```bash
-axelard q nexus transfer-fee terra avalanche 1000000000uusd
+axelard q nexus transfer-fee terra osmosis 1000000000uusdc
 ```
 
-The per-chain fee info can be queried via
+The per-chain gas relayer fee info can be queried via
 
 ```bash
-axelard q nexus fee avalanche uusd
+axelard q nexus fee avalanche uusdc
 ```
 
-If the total amount of asset X sent to a deposit address A is NOT greater than the transfer fee,
-then those deposits will sit in the queue until a future deposit to A brings the total above the fee.
+If the total amount of a token sent to a deposit address A is NOT greater than the gas relayer fee
+then those deposits will wait in the queue until a future deposit to A brings the total above the fee.
 
-Additionally, users should be prepared to pay for any transaction fees assessed by the source chain when transferring funds into a deposit address.
-These fees are typically in the form of native tokens on that chain (for e.g. LUNA on Terra, ETH on Ethereum).
+The gas relayer fee does not include any transaction fee assessed by the source chain for transferring tokens into a deposit address. These fees are usually denominated in native tokens on that chain (for e.g. AVAX on Avalanche, ETH on Ethereum).
 
 ## Upgrade Path
 

--- a/pages/resources/testnet-2.md
+++ b/pages/resources/testnet-2.md
@@ -26,43 +26,58 @@ import IBCChannels from '../../components/ibc/channels'
   <IBCChannels environment="testnet-2" />
 </div>
 
-## Cross-chain transfer fee
+## Cross-chain relayer gas fee
 
-The Network (and thus the Satellite app) charges a base fee for all cross-chain transfers.
-This fee only depends on the source/destination chain and the asset and does NOT take a percentage from the transfer amount.
-When transferring an asset X from chain Y to chain Z, the transfer fee is the sum of per-chain fee for that asset.
-For e.g. a transfer of 1000 UST from Terra to Avalanche will have a fee of 1.5 UST (= 0.5 UST for Terra + 1.0 UST for Avalanche), and so the recipient will get 998.5 UST.
+The Axelar network charges a _relayer gas fee_ for all cross-chain token transfers in order to pay for network-level transaction ("gas") fees across chains.
+The relayer gas fee amount depends only on:
 
-| Asset symbol | Ethereum | non-Ethereum EVM | Cosmos Chains | Decimals | Unit   |
-| ------------ | -------- | ---------------- | ------------- | -------- | ------ |
-| UST          | 20 UST   | 1 UST            | 0.5 UST       | 6        | uusd   |
-| LUNA         | 0.2 LUNA | 0.01 LUNA        | 0.005 LUNA    | 6        | uluna  |
-| ATOM         | 0.7 ATOM | 0.04 ATOM        | 0.02 ATOM     | 6        | uatom  |
-| aUSDC        | 20 aUSDC | 1 aUSDC          | 0.5 aUSDC     | 6        | uausdc |
+- the asset
+- the source chain
+- the destination chain
 
-The current transfer fee can also be queried on the network with
+<Callout emoji="💡">
+  The relayer gas fee does NOT take a percentage from the transfer amount.
+</Callout>
+
+Example: a transfer of X USDC tokens from Ethereum to Osmosis will have a fee of 40.5 USDC (= 40 USDC for Ethereum + 0.5 USDC for Osmosis),
+and so the recipient will get X - 40.5 USDC tokens on Osmosis.
+
+| Asset symbol | Ethereum   | non-Ethereum EVM | Cosmos Chains | Decimals | Unit         |
+| ------------ | ---------- | ---------------- | ------------- | -------- | ------------ |
+| USDC         | 60 USDC    | 1 USDC           | 0.5 USDC      | 6        | uusdc        |
+| WETH         | 0.02 WETH  | N/A              | 0.0002 WETH   | 18       | weth-wei     |
+| WBTC         | 0.002 WBTC | N/A              | 0.00002 WBTC  | 8        | wbtc-satoshi |
+| DAI          | 60 DAI     | 1 DAI            | 0.5 DAI       | 18       | dai-wei      |
+| FRAX         | 60 FRAX    | 1 FRAX           | 0.5 FRAX      | 18       | frax-wei     |
+| USDT         | 60 USDT    | 1 USDT           | 0.5 USDT      | 6        | uusdt        |
+| ATOM         | 4 ATOM     | 0.1 ATOM         | 0.05 ATOM     | 6        | uatom        |
+| UST          | 80 UST     | 2 UST            | 1 UST         | 6        | uusd         |
+| LUNA         | 40 LUNA    | 1 LUNA           | 0.5 LUNA      | 6        | uluna        |
+| NGM          | 60 NGM     | 1 NGM            | 0.5 NGM       | 6        | ungm         |
+| EEUR         | 60 EEUR    | 1 EEUR           | 0.5 EEUR      | 6        | eeur         |
+
+The current gas relayer fee is also available via node query:
 
 ```bash
 axelard q nexus transfer-fee [source chain] [destination chain] [amount]
 ```
 
-For e.g., querying the example transfer above (note `1 UST = 10^6 uusd`),
+Example: transfer USDC from Ethereum to Osmosis. (The amount here is arbitrary---gas relayer fees do not depend on the amount. `1 USDC = 10^6 uusdc`).
 
 ```bash
-axelard q nexus transfer-fee terra avalanche 1000000000uusd
+axelard q nexus transfer-fee terra osmosis 1000000000uusdc
 ```
 
-The per-chain fee info can be queried via
+The per-chain gas relayer fee info can be queried via
 
 ```bash
-axelard q nexus fee avalanche uusd
+axelard q nexus fee avalanche uusdc
 ```
 
-If the total amount of asset X sent to a deposit address A is NOT greater than the transfer fee,
-then those deposits will sit in the queue until a future deposit to A brings the total above the fee.
+If the total amount of a token sent to a deposit address A is NOT greater than the gas relayer fee
+then those deposits will wait in the queue until a future deposit to A brings the total above the fee.
 
-Additionally, users should be prepared to pay for any transaction fees assessed by the source chain when transferring funds into a deposit address.
-These fees are typically in the form of native tokens on that chain (for e.g. LUNA on Terra, ETH on Ethereum).
+The gas relayer fee does not include any transaction fee assessed by the source chain for transferring tokens into a deposit address. These fees are usually denominated in native tokens on that chain (for e.g. AVAX on Avalanche, ETH on Ethereum).
 
 ## Upgrade Path
 

--- a/pages/resources/testnet-2.md
+++ b/pages/resources/testnet-2.md
@@ -1,5 +1,6 @@
 # Testnet
 
+import Callout from 'nextra-theme-docs/callout'
 import MarkdownPath from '../../components/markdown'
 import EVMChains from '../../components/evm/chains'
 import EVMAssets from '../../components/evm/assets'

--- a/pages/resources/testnet.md
+++ b/pages/resources/testnet.md
@@ -1,5 +1,6 @@
 # Testnet
 
+import Callout from 'nextra-theme-docs/callout'
 import MarkdownPath from '../../components/markdown'
 import EVMChains from '../../components/evm/chains'
 import EVMAssets from '../../components/evm/assets'

--- a/pages/resources/testnet.md
+++ b/pages/resources/testnet.md
@@ -5,11 +5,11 @@ import EVMChains from '../../components/evm/chains'
 import EVMAssets from '../../components/evm/assets'
 import IBCChannels from '../../components/ibc/channels'
 
-| Variable              | Value         |
-| ----------------------| ------------- |
-| `axelar-core` version | `v0.17.0`     |
-| `vald` version        | `v0.17.0`     |
-| `tofnd` version       | `v0.8.2`      |
+| Variable              | Value     |
+| --------------------- | --------- |
+| `axelar-core` version | `v0.17.0` |
+| `vald` version        | `v0.17.0` |
+| `tofnd` version       | `v0.8.2`  |
 
 <div className="space-y-1 mt-4">
   ## EVM Chains
@@ -26,43 +26,58 @@ import IBCChannels from '../../components/ibc/channels'
   <IBCChannels environment="testnet" />
 </div>
 
-## Cross-chain transfer fee
+## Cross-chain relayer gas fee
 
-The Network (and thus the Satellite app) charges a base fee for all cross-chain transfers.
-This fee only depends on the source/destination chain and the asset and does NOT take a percentage from the transfer amount.
-When transferring an asset X from chain Y to chain Z, the transfer fee is the sum of per-chain fee for that asset.
-For e.g. a transfer of 1000 UST from Terra to Avalanche will have a fee of 1.5 UST (= 0.5 UST for Terra + 1.0 UST for Avalanche), and so the recipient will get 998.5 UST.
+The Axelar network charges a _relayer gas fee_ for all cross-chain token transfers in order to pay for network-level transaction ("gas") fees across chains.
+The relayer gas fee amount depends only on:
 
-| Asset symbol | Ethereum | non-Ethereum EVM | Cosmos Chains  | Decimals  | Unit     |
-| ------------ | -------- | ---------------- | -------------- | --------- | -------- |
-| UST          | 20 UST   | 1 UST            | 0.5 UST        | 6         | uusd     |
-| LUNA         | 0.2 LUNA | 0.01 LUNA        | 0.005 LUNA     | 6         | uluna    |
-| ATOM         | 0.7 ATOM | 0.04 ATOM        | 0.02 ATOM      | 6         | uatom    |
-| aUSDC        | 20 aUSDC | 1 aUSDC          | 0.5 aUSDC      | 6         | uausdc   |
+- the asset
+- the source chain
+- the destination chain
 
-The current transfer fee can also be queried on the network with
+<Callout emoji="💡">
+  The relayer gas fee does NOT take a percentage from the transfer amount.
+</Callout>
+
+Example: a transfer of X USDC tokens from Ethereum to Osmosis will have a fee of 40.5 USDC (= 40 USDC for Ethereum + 0.5 USDC for Osmosis),
+and so the recipient will get X - 40.5 USDC tokens on Osmosis.
+
+| Asset symbol | Ethereum   | non-Ethereum EVM | Cosmos Chains | Decimals | Unit         |
+| ------------ | ---------- | ---------------- | ------------- | -------- | ------------ |
+| USDC         | 60 USDC    | 1 USDC           | 0.5 USDC      | 6        | uusdc        |
+| WETH         | 0.02 WETH  | N/A              | 0.0002 WETH   | 18       | weth-wei     |
+| WBTC         | 0.002 WBTC | N/A              | 0.00002 WBTC  | 8        | wbtc-satoshi |
+| DAI          | 60 DAI     | 1 DAI            | 0.5 DAI       | 18       | dai-wei      |
+| FRAX         | 60 FRAX    | 1 FRAX           | 0.5 FRAX      | 18       | frax-wei     |
+| USDT         | 60 USDT    | 1 USDT           | 0.5 USDT      | 6        | uusdt        |
+| ATOM         | 4 ATOM     | 0.1 ATOM         | 0.05 ATOM     | 6        | uatom        |
+| UST          | 80 UST     | 2 UST            | 1 UST         | 6        | uusd         |
+| LUNA         | 40 LUNA    | 1 LUNA           | 0.5 LUNA      | 6        | uluna        |
+| NGM          | 60 NGM     | 1 NGM            | 0.5 NGM       | 6        | ungm         |
+| EEUR         | 60 EEUR    | 1 EEUR           | 0.5 EEUR      | 6        | eeur         |
+
+The current gas relayer fee is also available via node query:
 
 ```bash
 axelard q nexus transfer-fee [source chain] [destination chain] [amount]
 ```
 
-For e.g., querying the example transfer above (note `1 UST = 10^6 uusd`),
+Example: transfer USDC from Ethereum to Osmosis. (The amount here is arbitrary---gas relayer fees do not depend on the amount. `1 USDC = 10^6 uusdc`).
 
 ```bash
-axelard q nexus transfer-fee terra avalanche 1000000000uusd
+axelard q nexus transfer-fee terra osmosis 1000000000uusdc
 ```
 
-The per-chain fee info can be queried via
+The per-chain gas relayer fee info can be queried via
 
 ```bash
-axelard q nexus fee avalanche uusd
+axelard q nexus fee avalanche uusdc
 ```
 
-If the total amount of asset X sent to a deposit address A is NOT greater than the transfer fee,
-then those deposits will sit in the queue until a future deposit to A brings the total above the fee.
+If the total amount of a token sent to a deposit address A is NOT greater than the gas relayer fee
+then those deposits will wait in the queue until a future deposit to A brings the total above the fee.
 
-Additionally, users should be prepared to pay for any transaction fees assessed by the source chain when transferring funds into a deposit address.
-These fees are typically in the form of native tokens on that chain (for e.g. LUNA on Terra, ETH on Ethereum).
+The gas relayer fee does not include any transaction fee assessed by the source chain for transferring tokens into a deposit address. These fees are usually denominated in native tokens on that chain (for e.g. AVAX on Avalanche, ETH on Ethereum).
 
 ## Upgrade Path
 


### PR DESCRIPTION
Request:
> Rename "fees" to "relayer gas fees" and make it clear that these fees are to cover gas costs across chains.

I think this is mostly already done, so there's not much to do in this PR.  The only non-trivial change is in "resources" section.