### PR TITLE
Adding uni-3 Juno Testnet to axelar-testnet-lisbon-3

### DIFF
--- a/data/cosmos_chains.json
+++ b/data/cosmos_chains.json
@@ -50,12 +50,12 @@
     {
       "id": "crescent",
       "name": "Crescent",
-      "image": "/images/chains/crescent.jpg"
+      "image": "/images/chains/crescent.png"
     },
     {
       "id": "juno",
       "name": "Junø",
-      "image": "/images/chains/juno.jpg"
+      "image": "/images/chains/juno.png"
     }
   ],
   "testnet-2": [

--- a/data/cosmos_chains.json
+++ b/data/cosmos_chains.json
@@ -51,6 +51,11 @@
       "id": "crescent",
       "name": "Crescent",
       "image": "/images/chains/crescent.jpg"
+    },
+    {
+      "id": "juno",
+      "name": "Junø",
+      "image": "/images/chains/juno.jpg"
     }
   ],
   "testnet-2": [

--- a/data/ibc_channels.json
+++ b/data/ibc_channels.json
@@ -81,6 +81,16 @@
       "from": "axelarnet",
       "to": "crescent",
       "channel_id": "channel-6"
+    },
+    {
+      "from": "juno",
+      "to": "axelarnet",
+      "channel_id": "channel-4"
+    },
+    {
+      "from": "axelarnet",
+      "to": "juno",
+      "channel_id": "channel-16"
     }
   ]
 }


### PR DESCRIPTION
Opened channels between `axelar-testnet-lisbon-3` and `uni-3`

```
Success: Channel {
    ordering: Unordered,
    a_side: ChannelSide {
        chain: BaseChainHandle {
            chain_id: ChainId {
                id: "uni-3",
                version: 3,
            },
            runtime_sender: Sender { .. },
        },
        client_id: ClientId(
            "07-tendermint-11",
        ),
        connection_id: ConnectionId(
            "connection-4",
        ),
        port_id: PortId(
            "transfer",
        ),
        channel_id: Some(
            ChannelId(
                "channel-4",
            ),
        ),
        version: None,
    },
    b_side: ChannelSide {
        chain: BaseChainHandle {
            chain_id: ChainId {
                id: "axelar-testnet-lisbon-3",
                version: 3,
            },
            runtime_sender: Sender { .. },
        },
        client_id: ClientId(
            "07-tendermint-45",
        ),
        connection_id: ConnectionId(
            "connection-16",
        ),
        port_id: PortId(
            "transfer",
        ),
        channel_id: Some(
            ChannelId(
                "channel-16",
            ),
        ),
        version: None,
    },
    connection_delay: 0ns,
}
```