### PR TITLE
feat: add a new Error Execution Message page

### DIFF
--- a/pages/dev/gmp/executor-service.md
+++ b/pages/dev/gmp/executor-service.md
@@ -9,5 +9,5 @@ The Executor service supports Two-way call, where a message is sent from a sourc
 
 The service monitors if there's another contract call immediately executed within the same executed transaction on the destination (to send a message back to the source chain). The service will then automatically uses the remaining pre-paid to relay the second call of the two-way call. 
 
-In case the remaining gas amount (from the first contract call) is insufficient for the second call, the service will refund it to the payer's address. Users still can pay a new gas amount to relay the second call of the transfer through the [Axelar SDK](/dev/axelarjs-sdk/tx-status-query-recovery#22-erc-20-gas-payment) or [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain).
+In case the remaining gas amount (from the first contract call) is insufficient for the second call, the service will refund it to the payer's address. Users still can pay a new gas amount to relay the second call of the transfer through the [Axelar SDK](/dev/axelarjs-sdk/tx-status-query-recovery#2-increase-gas-payment) or [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain).
 

--- a/pages/dev/gmp/executor-service.md
+++ b/pages/dev/gmp/executor-service.md
@@ -1,10 +1,8 @@
 # Executor service 
 
-Axelar network provides an optional relayer service, called Executor service, which observes the gas-paid amount to the [Gas Service](/dev/gmp/gas-services/overview) contract, and automatically uses those amounts to relay the approved message to the application’s destination contract.
+Axelar network provides an optional relayer service, called Executor service, which observes the gas-paid amount to the [Gas Service](/dev/gmp/gas-services/overview) contract. Then, it automatically uses those amounts to relay the approved message to the application’s destination contract.
 
-To activate the use of the executor service, users are required to pay gas to the [Gas Service](/dev/gmp/gas-services/overview) contract on the source chain. The executor service will then handle relaying the message to the destination contract on the destination chain, and also [refund](/dev/gmp/gas-services/refund) the remaining gas used to the payer account at the end of the process. 
-
-So, only a couple of things are required to make a GMP transfer with the Executor service: 1) call the contract (`callContract` or `callContractWithToken`) and 2) pay gas to the [Gas Service](/dev/gmp/gas-services/overview) contract.
+Users are required to pay gas to the [Gas Service](/dev/gmp/gas-services/overview) contract to activate the executor service. After an attempt to relay the message to the destination contract, the service calculates the remaining gas amount and [refunds](/dev/gmp/gas-services/refund) it to the payer account. The execution result can be monitored on Axelarscan UI or requested through the AxelarJS SDK. Please see the [Monitoring State of GMP Transactions](/dev/gmp/gmp-tracker-recovery/monitoring) section for more information.
 
 ## Two-way call
 The Executor service supports Two-way call, where a message is sent from a source chain, immediately executed at a destination chain, and sent another message back to the source chain.

--- a/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
+++ b/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
@@ -8,11 +8,11 @@ Below are some possible errors that could be found in the execution step.
 There're two reasons that caused execution failed:
 ## 1. Insufficient prepaid gas to execute the transaction
 **Solution:** There're two options. 
-1) Manually execute the payload at the destination chain. See how to manually execute a transfer via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#manually-execute-a-transfer). 
-2) Pay a new gas amount on the source chain. See how to increase gas payment to the gas receiver from the source chain via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain) or [AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery#2-increase-gas-payment).
+1) Manually execute the payload at the destination chain via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#manually-execute-a-transfer) or [AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery#1-execute-manually).
+2) Pay a new gas amount to the Gas Service contract on the source chain via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain) or [AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery#2-increase-gas-payment).
 
 ## 2. Error in the destination contract logic
-**What to do next:** We suggest debugging it, then trying a new call.
+**What to do next:** We suggest debugging your contract and then making a new call.
 
 <Callout emoji="ℹ️">
   The displayed error is extracted from the data returned by the [Ethers.js](https://github.com/ethers-io/ethers.js/) library, from the data fields `error.error.code` and `error.error.reason`. The displayed error code can be clicked to link to the description of each error code in [Ethers.js's official document](https://docs.ethers.io/v5/api/utils/logger/#errors-ethereum). 

--- a/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
+++ b/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
@@ -1,0 +1,20 @@
+# Execution Error Messages
+
+import Callout from 'nextra-theme-docs/callout'
+
+Below are some possible errors that could be found in the execution step.
+![execute-errors-example.png](/images/execute-errors-example.png)
+
+There're two reasons that caused execution failed:
+## 1. Insufficient prepaid gas to execute the transaction
+**Solution:** There're two options. 
+1) Manually execute the payload at the destination chain. See how to manually execute a transfer via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#manually-execute-a-transfer). 
+2) Pay a new gas amount on the source chain. See how to increase gas payment to the gas receiver from the source chain via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain) or [AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery#2-increase-gas-payment).
+
+## 2. Error in the destination contract logic
+**What to do next:** We suggest debugging it, then trying a new call. 
+[will add suggestions how to debug it here @Euro]
+
+<Callout emoji="ℹ️">
+  The displayed error is extracted from the data returned by the [Ethers.js](https://github.com/ethers-io/ethers.js/) library, from the data fields `error.error.code` and `error.error.reason`. The displayed error code can be clicked to link to the description of each error code in [Ethers.js's official document](https://docs.ethers.io/v5/api/utils/logger/#errors-ethereum). 
+</Callout>

--- a/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
+++ b/pages/dev/gmp/gmp-tracker-recovery/error-debugging.md
@@ -12,8 +12,7 @@ There're two reasons that caused execution failed:
 2) Pay a new gas amount on the source chain. See how to increase gas payment to the gas receiver from the source chain via [Axelarscan UI](/dev/gmp/gmp-tracker-recovery/recovery#increase-gas-payment-to-the-gas-receiver-on-the-source-chain) or [AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery#2-increase-gas-payment).
 
 ## 2. Error in the destination contract logic
-**What to do next:** We suggest debugging it, then trying a new call. 
-[will add suggestions how to debug it here @Euro]
+**What to do next:** We suggest debugging it, then trying a new call.
 
 <Callout emoji="ℹ️">
   The displayed error is extracted from the data returned by the [Ethers.js](https://github.com/ethers-io/ethers.js/) library, from the data fields `error.error.code` and `error.error.reason`. The displayed error code can be clicked to link to the description of each error code in [Ethers.js's official document](https://docs.ethers.io/v5/api/utils/logger/#errors-ethereum). 

--- a/pages/dev/gmp/gmp-tracker-recovery/meta.json
+++ b/pages/dev/gmp/gmp-tracker-recovery/meta.json
@@ -1,5 +1,6 @@
 {
     "monitoring": "Monitoring State of Transactions",
+    "error-debugging": "Error message & Debugging",
     "recovery": "Transaction Recovery"
   }
   

--- a/pages/dev/gmp/gmp-tracker-recovery/monitoring.md
+++ b/pages/dev/gmp/gmp-tracker-recovery/monitoring.md
@@ -1,4 +1,5 @@
 # Monitoring State of GMP Transactions
+
 Axelar provides two options to check each GMP transaction status: 
 1. The Axelarscan UI. 
 2. The [[AxelarJS SDK](/dev/axelarjs-sdk/token-transfer-dep-addr)].
@@ -19,17 +20,8 @@ Once you navigate to the detailed transfer page, you will see four main statuses
 - **CONTRACT CALL** provides the contract call (`callContract` or `callContractWithToken`) information, including the transaction hash, the block height on the source chain, the gateway address, etc.
 - **GAS PAID** displays the information of the prepaid gas to Axelar Gas Service contract.
 - **CALL APPROVED** displays the information on the call approval. This section will be updated once the Axelar network approves the call. 
-- **EXECUTED** informs the execution result whether the execution is successful or not. 
+- **EXECUTED** informs the execution result whether the execution is successful or not. If it's unsuccessful, there will be [error message](/dev/gmp/gmp-tracker-recovery/error-debugging) with cause displayed in this section. 
 - **GAS REFUNDED** (optional) provides the refund information (if any), including the amount of gas paid, the amount of gas used, the refund amount, etc. This information will be shown up only when there’s a refund.
-
-### Execution Error Messages
-There could be multiple reasons that cause the unsuccessful execution. The below image shows some possible cases that could be found.
-
-![execute-errors-example.png](/images/execute-errors-example.png)
-
-The displayed error information is extracted from the data returned by the [Ethers.js](https://github.com/ethers-io/ethers.js/) library, from the data fields `error.error.code` and `error.error.reason`; you can see more information about each error message in [the official Ethers.js document](https://docs.ethers.io/v5/). The displayed error code (the red circle one) can also be clicked. It links straight to the description of each related error code in the [document](https://docs.ethers.io/v5/api/utils/logger/#errors-ethereum). 
-
-Additionally, some errors can be recovered via our provided [recovery methods](/dev/gmp/gmp-tracker-recovery/recovery). Otherwise, it could be an issue with the application’s destination contract.
 
 
 ## 2. AxelarJS SDK

--- a/pages/dev/gmp/gmp-tracker-recovery/monitoring.md
+++ b/pages/dev/gmp/gmp-tracker-recovery/monitoring.md
@@ -2,7 +2,7 @@
 
 Axelar provides two options to check each GMP transaction status: 
 1. The Axelarscan UI. 
-2. The [[AxelarJS SDK](/dev/axelarjs-sdk/token-transfer-dep-addr)].
+2. The [[AxelarJS SDK](/dev/axelarjs-sdk/tx-status-query-recovery)].
 
 ## 1. Axelarscan UI
 Anyone can view a General Message Passing transaction on the GMP page of the Axelarscan block explorer.


### PR DESCRIPTION
edit some existing detail about the Error Execution Message and move them to a new separate page (in the GMP's `monitoring-recovery` section)