### PR TITLE
Removing QuantNode HTTP2 SSL gRPCweb endpoints from resources.json

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -126,9 +126,6 @@
           "value": "axelar-grpcweb.quantnode.tech:9091"
         },
         {
-          "value": "https://axelar-grpcweb.quantnode.tech"
-        },
-        {
           "value": "axelar-grpc.polkachu.com:15190"
         },
         {
@@ -231,9 +228,6 @@
         },
         {
           "value": "axelartest-grpcweb.quantnode.tech:9091"
-        },
-        {
-          "value": "https://axelartest-grpcweb.quantnode.tech"
         }
       ]
     },


### PR DESCRIPTION
Removing QuantNode HTTP2 SSL gRPCweb endpoints from resources.json Broke letencrypt and seems is not needed