### PR TITLE
feat: upload axelard cli docs in axelar docs

### DIFF
--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -6,7 +6,7 @@ on:
       - feat/update-cli-docs
 
 jobs:
-  audit-iac:
+  update-cli-docs:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -1,9 +1,11 @@
 name: 'Update cli docs'
 
 on:
-  push:
-    branches:
-      - feat/update-cli-docs
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'CLI doc version to upload'
+        required: true
 
 jobs:
   update-cli-docs:
@@ -23,11 +25,11 @@ jobs:
 
       - name: Create new branch
         run: |  
-          git checkout -b feat/upload-cli-docs-v0_28_0
+          git checkout -b feat/upload-cli-docs-${{ github.event.inputs.version }}
 
       - name: Create version folder
         run: |  
-          test -d "pages/cli-docs/v0_28_0" || mkdir -p pages/cli-docs/v0_28_0 
+          test -d "pages/cli-docs/${{ github.event.inputs.version }}" || mkdir -p pages/cli-docs/${{ github.event.inputs.version }} 
 
       - name: Clone axelar-core repo
         run: |  
@@ -35,7 +37,7 @@ jobs:
 
       - name: Copy cli docs to web docs
         run: |  
-          cp axelar-core/docs/cli/* pages/cli-docs/v0_28_0
+          cp axelar-core/docs/cli/* pages/cli-docs/${{ github.event.inputs.version }}
           rm -fr axelar-core
 
       - name: Commit files
@@ -43,10 +45,10 @@ jobs:
           git config --local user.email "kalid@axelar.network"
           git config --local user.name "kalid"
           git add --all
-          git commit -m "chore(upload-cli-docs): upload cli docs version 0.28.0"
+          git commit -m "chore(upload-cli-docs): upload cli docs version ${{ github.event.inputs.version }}"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: feat/upload-cli-docs-v0_28_0
+          branch: feat/upload-cli-docs-${{ github.event.inputs.version }}

--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -44,3 +44,9 @@ jobs:
           git config --local user.name "kalid"
           git add --all
           git commit -m "chore(upload-cli-docs): upload cli docs version 0.28.0"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: feat/upload-cli-docs-v0_28_0

--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -1,0 +1,22 @@
+name: 'Update cli docs'
+
+on:
+  push:
+    branches:
+      - feat/update-cli-docs
+
+jobs:
+  audit-iac:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2

--- a/.github/workflows/update-cli-docs.yaml
+++ b/.github/workflows/update-cli-docs.yaml
@@ -20,3 +20,27 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
+
+      - name: Create new branch
+        run: |  
+          git checkout -b feat/upload-cli-docs-v0_28_0
+
+      - name: Create version folder
+        run: |  
+          test -d "pages/cli-docs/v0_28_0" || mkdir -p pages/cli-docs/v0_28_0 
+
+      - name: Clone axelar-core repo
+        run: |  
+          git clone https://github.com/axelarnetwork/axelar-core.git 
+
+      - name: Copy cli docs to web docs
+        run: |  
+          cp axelar-core/docs/cli/* pages/cli-docs/v0_28_0
+          rm -fr axelar-core
+
+      - name: Commit files
+        run: |
+          git config --local user.email "kalid@axelar.network"
+          git config --local user.name "kalid"
+          git add --all
+          git commit -m "chore(upload-cli-docs): upload cli docs version 0.28.0"


### PR DESCRIPTION
Action on demand to update cli docs.

- It will create a new branch using the pattern "feat/upload-cli-docs-${{ github.event.inputs.version }}"
- It will copy to cli docs generated from axelar core to our documentation repo
- It will push the changes 
- It is up to the requester to make the PR or not