### PR TITLE
fix: change references to IAxelarExecutable to recommend AxelarExecutable instead

### DIFF
--- a/pages/dev/general-message-passing/gmp-messages.mdx
+++ b/pages/dev/general-message-passing/gmp-messages.mdx
@@ -5,7 +5,7 @@ import { Callout } from 'nextra-theme-docs'
 To call a contract on chain B from chain A, the user needs to call `callContract` on the gateway of chain A, specifying:
 
 - The destination chain, which must be an EVM chain from [Chain names](./chain-names).
-- The destination contract address, which must implement the `IAxelarExecutable` interface defined in [IAxelarExecutable.sol](https://github.com/axelarnetwork/axelar-cgp-solidity/blob/main/contracts/interfaces/IAxelarExecutable.sol).
+- The destination contract address, which must inherit from `AxelarExecutable` defined in [AxelarExecutable.sol](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/executables/AxelarExecutable.sol).
 - The payload `bytes` to pass to the destination contract.
 
 ```solidity
@@ -16,7 +16,7 @@ function callContract(
 ) external;
 ```
 
-`IAxelarExecutable` has an `_execute` function that will be triggered by the Axelar network after the `callContract` function has been executed. You can write any custom logic there.
+`AxelarExecutable` has an `execute` function that will be triggered by the Axelar network on the destination chain after the `callContract` function has been executed on the source chain. This will validate the contract call and then invoke *your* `_execute` method, where you should write any custom logic.
 
 ```solidity
 function _execute(

--- a/pages/dev/general-message-passing/gmp-tokens-with-messages.mdx
+++ b/pages/dev/general-message-passing/gmp-tokens-with-messages.mdx
@@ -6,7 +6,7 @@ import { Callout } from 'nextra-theme-docs'
 To call chain B from chain A and send some tokens along the way, the user needs to call `callContractWithToken` on the gateway of chain A, specifying:
 
 - The destination chain, which must be an EVM chain from [Chain names](./chain-names).
-- The destination contract address, which must implement the `IAxelarExecutable` interface defined in [IAxelarExecutable.sol](https://github.com/axelarnetwork/axelar-cgp-solidity/blob/main/contracts/interfaces/IAxelarExecutable.sol).
+- The destination contract address, which must inherit from `AxelarExecutable` defined in [AxelarExecutable.sol](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/executables/AxelarExecutable.sol).
 - The payload `bytes` to pass to the destination contract.
 - The symbol of the token to transfer, which must be a supported asset ([Mainnet](../build/contract-addresses/mainnet) | [Testnet](../build/contract-addresses/testnet)).
 - The amount of the token to transfer.
@@ -23,7 +23,7 @@ function callContractWithToken(
 ) external;
 ```
 
-`IAxelarExecutable` has an `_executeWithToken` function that will be triggered by the Axelar network after the `callContractWithToken` function has been executed. You can write any custom logic there.
+`AxelarExecutable` has an `executeWithToken` function that will be triggered by the Axelar network on the destination chain after the `callContractWithToken` function has been executed on the source chain. This will validate the contract call and then invoke *your* `_executeWithToken` method, where you should write any custom logic.
 
 The destination contract will be authorized to transfer the ERC-20 identified by the `tokenSymbol`.
 

--- a/pages/dev/reference/mainnet-chain-names.mdx
+++ b/pages/dev/reference/mainnet-chain-names.mdx
@@ -4,7 +4,7 @@ import ChainList from '../../../components/chainlist';
 
 The following values are legal arguments for token transfers and General Message Passing calls such as `callContract` and `callContractWithToken`.
 
-The contract call approval at the Axelar gateway and contracts implementing `IAxelarExecutable` contracts will receive precisely these values for the source chain.
+The contract call approval at the Axelar gateway and contracts inheriting `AxelarExecutable` contracts will receive precisely these values from the source chain.
 
 Note these names are case-sensitive.
 

--- a/pages/dev/reference/testnet-chain-names.mdx
+++ b/pages/dev/reference/testnet-chain-names.mdx
@@ -4,7 +4,7 @@ import ChainList from '../../../components/chainlist';
 
 The following values are legal arguments for token transfers and General Message Passing calls such as `callContract` and `callContractWithToken`.
 
-The contract call approval at the Axelar gateway and contracts implementing `IAxelarExecutable` contracts will receive precisely these values for the source chain.
+The contract call approval at the Axelar gateway and contracts inheriting `AxelarExecutable` will receive precisely these values from the source chain.
 
 Note these names are case-sensitive.
 


### PR DESCRIPTION
If developers implement the interface directly, they'll need to manually verify the contract call, which is not recommended. Instead, developers should be extending `AxelarExecutable`, and only implementing the relevant `_execute` method.

CC: @vladwulf per our conversation today