### PR TITLE
fix: add correct path to broken link in pay-gas page

### DIFF
--- a/pages/dev/general-message-passing/gas-services/pay-gas.mdx
+++ b/pages/dev/general-message-passing/gas-services/pay-gas.mdx
@@ -86,7 +86,7 @@ function payNativeGasForContractCall(
 Similar to the available gas payment methods for `callContract`, there are two available methods to pay gas for relaying the `callContractWithToken`.
 
 ### payGasForContractCallWithToken
-This method receives any tokens for the relayer fee. The paid gas for this method must be in tokens Axelar supports. See the list of supported assets: [Mainnet](../reference/mainnet-contract-addresses) | [Testnet](../reference/testnet-contract-addresses).
+This method receives any tokens for the relayer fee. The paid gas for this method must be in tokens Axelar supports. See the list of supported assets: [Mainnet](../../reference/mainnet-contract-addresses) | [Testnet](../../reference/testnet-contract-addresses).
 
 ```solidity
 // This is called on the source chain before calling the gateway to execute a remote contract.


### PR DESCRIPTION
Fixes #417 