### PR TITLE
chore: update gov proposal community-pool-spend cli

### DIFF
--- a/pages/resources/governance/community-pool-proposals.mdx
+++ b/pages/resources/governance/community-pool-proposals.mdx
@@ -44,7 +44,7 @@ $ axelard tx bank send [account_with_fund_address] [wallet_address] 2000000000ua
 Now that you have a account named `wallet` with 2,000AXL, you can submit a proposal on-chain. Access the Axelar's RPC providers [here](/resources)
 
 ```bash
-$ axelard tx gov submit-proposal community-pool-spend <file> --from wallet --node <RPC Endpoint> --gas auto --gas-adjustment 1.2
+$ axelard tx gov submit-proposal community-pool-spend <file> --from wallet --chain-id axelar-dojo-1 --node <RPC Endpoint> --gas auto --gas-adjustment 1.2
 ```
 
 


### PR DESCRIPTION
`--chain-id axelar-dojo-1` needs to be explicitly specified if `AXELARD_CHAIN_ID` not set, other wise following error will happen  
```
{"height":"0","txhash":"997782FA19F3158D66632111F0287621B9ED1667F2CAEE78BBCC3335D6991F2B","codespace":"sdk","code":4,"data":"","raw_log":"signature verification failed; please verify account number (284247) and chain-id (axelar-doj
o-1):unauthorized","logs":[],"info":"","gas_wanted":"257751","gas_used":"54670","tx":null,"timestamp":"","events":[]}
```