### PR TITLE
CometBFT Time Change

### DIFF
--- a/src/pages/learn/txduration.mdx
+++ b/src/pages/learn/txduration.mdx
@@ -63,7 +63,7 @@ This data is available on the [Axelarscan block explorer under the heading **GMP
 | BNB | 46 seconds | 15 blocks
 | Fantom | 3 seconds| 1 block
 | Kava | 45 seconds| 1 block
-| CometBFT (Formerly Tendermint) | 1-3 seconds |
+| CometBFT (Formerly Tendermint) | Instant |
 | Optimism | 30 minutes | 1000000 blocks
 | Linea | 81 minutes | 400 blocks
 | Filecoin | 52 minutes | 100 blocks


### PR DESCRIPTION
minor inaccuracy in our table for finality on time for cometbft. It says 1-3 seconds when it is in fact instant 