### PR TITLE
fix: Update link that redirect to deployed contracts

### DIFF
--- a/src/pages/dev/send-tokens/interchain-tokens.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens.mdx
@@ -154,7 +154,7 @@ To help understand the Interchain Token Service, here are some definitions of te
 A contract deployed by Axelar that manages the creation and management of Interchain Tokens and Token Managers.
 
 The Interchain Token Service has an address of [0xF786e21509A9D50a9aFD033B5940A2b7D872C208](https://goerli.etherscan.io/address/0xF786e21509A9D50a9aFD033B5940A2b7D872C208) on all testnet chains,
-deployed from the [v0.3.0](https://github.com/axelarnetwork/interchain-token-service/releases/tag/v0.3.0) release. Deployed addresses can be found [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/info/testnet.json).
+deployed from the [v0.3.0](https://github.com/axelarnetwork/interchain-token-service/releases/tag/v0.3.0) release. Deployed addresses can be found [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/testnet.json).
 
 #### Token Manager
 A contract created by the Interchain Token Service that is capable of locking and releasing tokens, or minting and burning them, depending on its type.


### PR DESCRIPTION
Hello.

Merging this PR will fix a broken link that is supposed to link to the pages of the deployed smart contracts