### PR TITLE
fix: revert assets heading

### DIFF
--- a/src/pages/resources/mainnet.mdx
+++ b/src/pages/resources/mainnet.mdx
@@ -27,7 +27,8 @@ import UpgradePath from '/src/upgrade-path.md'
 </div>
 
 <div className="space-y-1 mt-4">
-  ### Assets Learn more about [wrapped assets like axlUSDC](/learn/axlusdc).
+  ### Assets
+  Learn more about [wrapped assets like axlUSDC](/learn/axlusdc).
   <EVMAssets client:only environment="mainnet" />
 </div>
 


### PR DESCRIPTION
The heading for Assets has changed breaking existing links to it.