### PR TITLE
Remove reference to PayGasForContractCall

### DIFF
--- a/src/pages/dev/general-message-passing/gas-services/pay-gas.mdx
+++ b/src/pages/dev/general-message-passing/gas-services/pay-gas.mdx
@@ -84,29 +84,7 @@ function payNativeGasForContractCall(
 ```
 
 ## Alternative gas payment methods for `callContractWithToken`
-{
-/* 
-Similar to the available gas payment methods for `callContract`, there are two available methods to pay gas for relaying the `callContractWithToken`.
 
-### payGasForContractCallWithToken
-This method receives any tokens for the relayer fee. The paid gas for this method must be in tokens Axelar supports. See the list of supported assets: [Mainnet](../../reference/mainnet-contract-addresses) | [Testnet](../../reference/testnet-contract-addresses).
-
-```solidity
-// This is called on the source chain before calling the gateway to execute a remote contract.
-function payGasForContractCallWithToken(
-    address sender,
-    string calldata destinationChain,
-    string calldata destinationAddress,
-    bytes calldata payload,
-    string calldata symbol,
-    uint256 amount,
-    address gasToken,
-    uint256 gasFeeAmount,
-    address refundAddress
-) external;
-``` 
-*/
-}
 
 ### payNativeGasForContractCallWithToken
 This method accepts the native tokens of the source chain.
@@ -129,21 +107,16 @@ The function names are prety self-explanatory. The following is true for the arg
 
 - For all functions:
   - `sender` needs to match the address that calls `callContract` or `callContractWithToken` on the `AxelarGateway`. If the `AxelarGasReceiver` is called by the same contract that will call the Gateway, then simply specify `address(this)` as `sender`.
-{/* - For `payGasForContractCall` and `payNativeGasForContractCall`, the following need to match the arguments of a `contractCall` on the `AxelarGateway`: */}
 - For `payNativeGasForContractCall`, the following need to match the arguments of a `contractCall` on the `AxelarGateway`:
   - `destinationChain`
   - `destinationAddress`
   - `payload`
-{/* - For `payGasForContractCallWithToken` and `payNativeGasForContractCallWithToken`, the following need to match the arguments of a `contractCallWithToken` on the `AxelarGateway`: */}
 - For `payNativeGasForContractCallWithToken`, the following need to match the arguments of a `contractCallWithToken` on the `AxelarGateway`:
   - `destinationChain`
   - `destinationAddress`
   - `payload`
   - `symbol`
   - `amount`
-{/* - For `payGasForContractCall` and `payGasForContractCallWtihToken`:
-  - `gasToken` is the address of the token that gas will be paid in. Ensure this token is supported by the network, using the Axelar API.
-  - `gasFeeAmount` is the amount of `gasToken` to transfer from the sender. The sender needs to have approved the `AxelarGasReceiver` with the appropriate amount to `gasToken` first. */}
 - For `payNativeGasForContractCall` and `payNativeGasForContractCallWithToken`, the amount of funds received is specified by `msg.value`.
 - For all functions, `refundAddress` is the address that will eventually be able to receive excess amount paid for gas.
 

--- a/src/pages/dev/general-message-passing/gas-services/pay-gas.mdx
+++ b/src/pages/dev/general-message-passing/gas-services/pay-gas.mdx
@@ -84,6 +84,8 @@ function payNativeGasForContractCall(
 ```
 
 ## Alternative gas payment methods for `callContractWithToken`
+{
+/* 
 Similar to the available gas payment methods for `callContract`, there are two available methods to pay gas for relaying the `callContractWithToken`.
 
 ### payGasForContractCallWithToken
@@ -102,7 +104,9 @@ function payGasForContractCallWithToken(
     uint256 gasFeeAmount,
     address refundAddress
 ) external;
-```
+``` 
+*/
+}
 
 ### payNativeGasForContractCallWithToken
 This method accepts the native tokens of the source chain.
@@ -125,19 +129,21 @@ The function names are prety self-explanatory. The following is true for the arg
 
 - For all functions:
   - `sender` needs to match the address that calls `callContract` or `callContractWithToken` on the `AxelarGateway`. If the `AxelarGasReceiver` is called by the same contract that will call the Gateway, then simply specify `address(this)` as `sender`.
-- For `payGasForContractCall` and `payNativeGasForContractCall`, the following need to match the arguments of a `contractCall` on the `AxelarGateway`:
+{/* - For `payGasForContractCall` and `payNativeGasForContractCall`, the following need to match the arguments of a `contractCall` on the `AxelarGateway`: */}
+- For `payNativeGasForContractCall`, the following need to match the arguments of a `contractCall` on the `AxelarGateway`:
   - `destinationChain`
   - `destinationAddress`
   - `payload`
-- For `payGasForContractCallWtihToken` and `payNativeGasForContractCallWithToken`, the following need to match the arguments of a `contractCallWithToken` on the `AxelarGateway`:
+{/* - For `payGasForContractCallWithToken` and `payNativeGasForContractCallWithToken`, the following need to match the arguments of a `contractCallWithToken` on the `AxelarGateway`: */}
+- For `payNativeGasForContractCallWithToken`, the following need to match the arguments of a `contractCallWithToken` on the `AxelarGateway`:
   - `destinationChain`
   - `destinationAddress`
   - `payload`
   - `symbol`
   - `amount`
-- For `payGasForContractCall` and `payGasForContractCallWtihToken`:
+{/* - For `payGasForContractCall` and `payGasForContractCallWtihToken`:
   - `gasToken` is the address of the token that gas will be paid in. Ensure this token is supported by the network, using the Axelar API.
-  - `gasFeeAmount` is the amount of `gasToken` to transfer from the sender. The sender needs to have approved the `AxelarGasReceiver` with the appropriate amount to `gasToken` first.
+  - `gasFeeAmount` is the amount of `gasToken` to transfer from the sender. The sender needs to have approved the `AxelarGasReceiver` with the appropriate amount to `gasToken` first. */}
 - For `payNativeGasForContractCall` and `payNativeGasForContractCallWithToken`, the amount of funds received is specified by `msg.value`.
 - For all functions, `refundAddress` is the address that will eventually be able to receive excess amount paid for gas.
 

--- a/src/pages/dev/general-message-passing/gas-services/refund.mdx
+++ b/src/pages/dev/general-message-passing/gas-services/refund.mdx
@@ -1,6 +1,8 @@
 # Refund the prepaid gas
 
-The prepaid gas to `payGasForContractCall` or `payGasForContractCallWithToken` could exceed the actual amount needed for relaying a message to the destination contract.
+{/* The prepaid gas to `payGasForContractCall` or `payGasForContractCallWithToken` could exceed the actual amount needed for relaying a message to the destination contract. */}
+The prepaid gas to `payNativeGasForContractCall` or `payNativeGasForContractCallWithToken` could exceed the actual amount needed for relaying a message to the destination contract.
+
 
 The Executor Service automatically tracks the excess gas amount and refund it to the payer's wallet address by calling `Refund` in the Gas Service contract.
 

--- a/src/pages/dev/general-message-passing/gas-services/refund.mdx
+++ b/src/pages/dev/general-message-passing/gas-services/refund.mdx
@@ -1,6 +1,5 @@
 # Refund the prepaid gas
 
-{/* The prepaid gas to `payGasForContractCall` or `payGasForContractCallWithToken` could exceed the actual amount needed for relaying a message to the destination contract. */}
 The prepaid gas to `payNativeGasForContractCall` or `payNativeGasForContractCallWithToken` could exceed the actual amount needed for relaying a message to the destination contract.
 
 


### PR DESCRIPTION
Was pointed out that we do not support payGasForContractCall we only support native gas payment. Commented out all references for now just in case we want to add this back in the docs later