### PR TITLE
Bugfix for testnet assets

### DIFF
--- a/src/data/evm_assets.json
+++ b/src/data/evm_assets.json
@@ -3203,7 +3203,7 @@
           "transfer_fee": 0.1
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x254d06f33bDc5b8ee05b2ea472107E300226659A",
           "symbol": "aUSDC",
           "decimals": 6,
@@ -3330,7 +3330,7 @@
           "transfer_fee": 0.1
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x23ee2343B892b1BB63503a4FAbc840E0e2C6810f",
           "symbol": "wAXL",
           "decimals": 6,
@@ -3508,7 +3508,7 @@
           "transfer_fee": 7e-05
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0xeA700DCe55e72C4C08b97AcFc7dF214EC30F4a64",
           "symbol": "axlWETH",
           "decimals": 18,
@@ -3635,7 +3635,7 @@
           "transfer_fee": 0.07
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x21ba4f6aEdA155DD77Cc33Fb93646910543F0380",
           "symbol": "WMATIC",
           "decimals": 18,
@@ -3762,7 +3762,7 @@
           "transfer_fee": 0.001
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x2a87806561C550ba2dA9677c5323413E6e539740",
           "symbol": "WAVAX",
           "decimals": 18,
@@ -3889,7 +3889,7 @@
           "transfer_fee": 0.08
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x594D8b81eC765410536ab59E98091700b99508D8",
           "symbol": "WFTM",
           "decimals": 18,
@@ -4016,7 +4016,7 @@
           "transfer_fee": 0.0003
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0xA9A2D8F279ABC436a18DBB1df3FB233039935D0A",
           "symbol": "WBNB",
           "decimals": 18,
@@ -4143,7 +4143,7 @@
           "transfer_fee": 0.04
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x4B13D583F45Aa01fb2bE18a7AAfE14DE183B1Ac9",
           "symbol": "WDEV",
           "decimals": 18,

--- a/src/pages/resources/testnet.mdx
+++ b/src/pages/resources/testnet.mdx
@@ -41,6 +41,7 @@ import UpgradePathTestnet from '/src/upgrade-path-testnet.md'
 
 <div className="space-y-1 mt-4">
   ### Assets
+    Learn more about [wrapped assets like axlUSDC](/learn/axlusdc).
   <EVMAssets client:only environment="testnet" />
 </div>
 


### PR DESCRIPTION
Renamed sepolia to `ethereum-sepolia` to fix bug on assets not appearing on testnet docs. 
Also added helper text to learn more on wrapped assets to match what we already have for mainnet assets