### PR TITLE
fix: update steps to create custom interchain token

### DIFF
--- a/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
@@ -1,101 +1,48 @@
-# Create a new Interchain Token
+# Create a New Interchain Token
 
-Interchain Tokens are ERC-20 tokens that are available on [multiple blockchains](https://docs.axelar.dev/resources/testnet). They are created using the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) and can be used to transfer value between blockchains.
+Interchain tokens are ERC-20 tokens that are available on [multiple blockchains](https://docs.axelar.dev/resources/testnet). They are created using the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) and can be used to transfer value between blockchains.
 
-The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66)
+The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66).
 
-Let's explore two methods to create new Interchain Token(s).
+You can create a new Interchain Token through the [Interchain Portal](https://testnet.interchain.axelar.dev/), or by building a custom ERC-20 token and deploying it with a Mint/Burn token manager on all chains. These tokens will be accessible on multiple blockchain networks, allowing for seamless interaction on each network by utilizing familiar methods such as send, transfer, and approve -- just as with any standard ERC-20 token.
 
 ## Create a new Interchain Token using the Interchain Token Portal
 
-The simplest type of Interchain Token is to create a brand new [Interchain Token](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) available on multiple chains. For a detailed guide on how to create an Interchain Token using the Interchain Token Portal, refer to the [four-step tutorial](https://axelar.network/blog/how-to-create-an-interchain-token-with-axelar-in-4-steps).
+The simplest way to create an Interchain Token is to do so through the portal:
 
-- Visit the [Interchain Portal](https://testnet.interchain.axelar.dev)
-- Connect your wallet to the portal
-- Select a source network where you have funds available
-- Choose the option to deploy a new Interchain token
-- Add the required details for your new token
+1. Visit the [Interchain Portal](https://testnet.interchain.axelar.dev).
+2. Connect your wallet.
+3. Select a source network where you have funds available.
+4. Select the option to deploy a new Interchain token.
+5. Add the required details for your new token:
     - Name
     - Symbol
     - Decimals
     - Amount to mint
-- You can also click the advanced option where you can add an account as `Token Minter` and `Salt` value. Otherwise, it gets prefilled with the deployer(connected account) address and a random, uniquely generated salt value
-- Select additional chains for your token's availability and optionally add the token amount to mint on each selected chain
+    You can also choose the advanced option where you can add an account as `Token Minter` and `Salt` value. Otherwise, these fields will be prefilled with the deployer (connected account) address and a random, uniquely generated salt value.
+6. Select additional chains for your token's availability. You can optionally add the token amount to mint on each selected chain.
 
-Congratulations! Your Interchain Token is now accessible on multiple blockchain networks. This allows for seamless interaction with your token on any of these networks, utilizing familiar methods like send, transfer, and approve, just as with any standard ERC-20 token.
+Congratulations! Your new Interchain Token is now available on multiple chains. Furthermore, it follows the [Interchain Token Standard](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/interfaces/IInterchainTokenStandard.sol), meaning that users can call the [`interchainTransfer()`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210) method on the token itself to transfer between blockchains.
 
-Furthermore, your token follows the [Interchain Token Standard](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/interfaces/IInterchainTokenStandard.sol). This means that users can call the `interchainTransfer` method on the token itself to transfer between blockchains.
-
-Here is an example of the `interchainTransfer` method.
-
-```solidity
-/**
- * @notice Initiates an interchain transfer of a specified token to a destination chain.
- * @dev The function retrieves the TokenManager associated with the tokenId.
- * @param tokenId The unique identifier of the token to be transferred.
- * @param destinationChain The destination chain to send the tokens to.
- * @param destinationAddress The address on the destination chain to send the tokens to.
- * @param amount The amount of tokens to be transferred.
- * @param metadata Optional metadata for the call for additional effects (such as calling a destination contract).
- */
-function interchainTransfer(
-    bytes32 tokenId,
-    string calldata destinationChain,
-    bytes calldata destinationAddress,
-    uint256 amount,
-    bytes calldata metadata,
-    uint256 gasValue
-) external payable
-```
+Refer to the [four-step tutorial](https://axelar.network/blog/how-to-create-an-interchain-token-with-axelar-in-4-steps) for more detailed steps on creating Interchain Tokens using the Interchain Token Portal.
 
 ## Create a custom Interchain Token
 
-If you want more features than the Interchain Token provides, you can create a [custom token](../../reference/glossary/#custom-token). You may want a customized token to customize specific minting policies, ownership structures, rate limits, or other bespoke functionalities.
+If you want your token to have more features than the standard Interchain Token, you can create a [custom token](../../reference/glossary/#custom-token). With these tokens, you can specify minting policies, ownership structures, rate limits, and other bespoke functionality.
 
 To create a custom Interchain Token:
 
-- Build your [ERC-20](https://docs.alchemy.com/docs/how-to-create-an-erc-20-token-4-steps) token and deploy it on multiple chains
-- Deploy a [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager) for existing tokens on all chains using [`deployTokenManager`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L276) on Interchain Token Service. The `deployTokenManager` method requires parameters like `salt`, `destinationChain`, `tokenManagerType`, `params`, and `gasValue`
-- Ensure the Interchain Token Service can invoke the `mint/burn` functions on the token by calling [`transferMintership`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/utils/Minter.sol#L31) on your token. This is to transfer the minter role to ITS on all chains, enabling it to mint/burn. Repeat this step for other chains where the token exists, using the same deployer address and salt 
+1. Build your [ERC-20](https://docs.alchemy.com/docs/how-to-create-an-erc-20-token-4-steps) token and deploy it on multiple chains.
+2. Deploy a [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager) for existing tokens on all chains using the [`deployTokenManager()`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L276) method on the Interchain Token Service.
+3. Ensure that the Interchain Token Service can invoke the `Mint/Burn` functions on the token by calling [`transferMintership()`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/utils/Minter.sol#L31) on your token. This will transfer the minter role to the ITS on all chains, enabling it to mint or burn tokens.
+    * Repeat this step on all other chains where the token exists, using the same deployer address and salt.
+4. Transfer Interchain Tokens between chains via the Interchain Token Service by calling [`interchainTransfer()`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210).
 
-Here is an example of how to transfer mintership:
+Tokens can move between chains seamlessly, as the Token Manager contracts will mint and burn tokens as needed. If the `minter` parameter consists of empty bytes when deploying a new Interchain Token, use a Mint/Burn `TokenManager`. Otherwise, use a Lock/Unlock `TokenManager`. Call `transferMintership()` on the token to change the token minter to another address.
 
-```solidity
-/**
- * @notice Changes the minter of the contract.
- * @dev Can only be called by the current minter.
- * @param minter_ The address of the new minter.
- */
-function transferMintership(address minter_) external
-```
-- Transfer Interchain Tokens between chains via the Interchain Token Service by calling the [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210)
+If you want to build a token with the `IInterchainToken` feature yourself, make sure that your token implements the [`IInterchainTokenStandard`](https://github.com/axelarnetwork/interchain-token-service/blob/v1.0.0/contracts/interfaces/IInterchainTokenStandard.sol) interface so you can offer the [`interchainTransfer()`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/interfaces/IInterchainTokenStandard.sol#L19) and [`interchainTransferFrom()`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/interfaces/IInterchainTokenStandard.sol#L36) methods directly on it.
 
-Here is an example of deploying a token manager:
-
-```solidity
-/**
- * @notice Used to deploy TokenManagers.
- * @dev At least the `gasValue` amount of native token must be passed to the function call. `gasValue` exists because this function can be
- * part of a multicall involving multiple functions that could make remote contract calls.
- * @param salt The salt to be used during deployment.
- * @param destinationChain The name of the chain to deploy the TokenManager and standardized token to.
- * @param tokenManagerType The type of TokenManager to be deployed.
- * @param params The params that will be used to initialize the TokenManager.
- * @param gasValue The amount of native tokens to be used to pay for gas for the remote deployment.
- * @return tokenId The tokenId corresponding to the deployed TokenManager.
- */
-function deployTokenManager(
-    bytes32 salt,
-    string calldata destinationChain,
-    TokenManagerType tokenManagerType,
-    bytes calldata params,
-    uint256 gasValue
-) external payable 
-```
-
-Tokens can move between chains seamlessly as the Token Manager contracts will mint and burn tokens as needed. If the `minter` parameter is empty bytes when deploying a new Interchain Token, use a Mint/Burn `TokenManager`. Otherwise, use a Lock/Unlock `TokenManager`. Use the `transferMintership` on the token to change the token minter to another address.
-
->**Note**: If you want to build your token with the `IInterchainToken` feature yourself, make sure your token implements the [`IInterchainTokenStandard`](https://github.com/axelarnetwork/interchain-token-service/blob/v1.0.0/contracts/interfaces/IInterchainTokenStandard.sol) interface so you can offer [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/interfaces/IInterchainTokenStandard.sol#L19) and [`interchainTransferFrom`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/interfaces/IInterchainTokenStandard.sol#L36) methods directly on your token. 
+### Sample custom token
 
 You can try our [sample custom token](https://remix.ethereum.org/axelarnetwork/axelar-docs/blob/main/public/samples/interchain-token-iinterchaintoken.sol) as a starting point. This token self-registers with the Interchain Token Service and can be deployed to multiple chains. 
 Once you have designed your token, you can deploy it to multiple chains using a tool such as the [Constant Address Deployer](https://docs.axelar.dev/dev/general-message-passing/solidity-utilities#constant-address-deployer) to give it the same address everywhere. 

--- a/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
@@ -4,7 +4,7 @@ Interchain tokens are ERC-20 tokens that are available on [multiple blockchains]
 
 The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66).
 
-You can create a new Interchain Token through the [Interchain Portal](https://testnet.interchain.axelar.dev/), or by building a custom ERC-20 token and deploying it with a Mint/Burn token manager on all chains. These tokens will be accessible on multiple blockchain networks, allowing for seamless interaction on each network by utilizing familiar methods such as send, transfer, and approve -- just as with any standard ERC-20 token.
+You can create a new Interchain Token through the [Interchain Portal](https://testnet.interchain.axelar.dev/), or by building a custom ERC-20 token and deploying it with a Mint/Burn token manager on all chains. These tokens will be accessible on multiple chains, allowing for seamless interaction on each chain by utilizing familiar methods such as send, transfer, and approve -- just as with any standard ERC-20 token.
 
 ## Create a new Interchain Token using the Interchain Token Portal
 

--- a/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
@@ -2,7 +2,7 @@
 
 Interchain tokens are ERC-20 tokens that are available on [multiple blockchains](https://docs.axelar.dev/resources/testnet). They are created using the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) and can be used to transfer value between blockchains.
 
-The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66).
+The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://etherscan.io/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://etherscan.io/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66).
 
 You can create a new Interchain Token through the [Interchain Portal](https://testnet.interchain.axelar.dev/), or by building a custom ERC-20 token and deploying it with a Mint/Burn token manager on all chains. These tokens will be accessible on multiple chains, allowing for seamless interaction on each chain by utilizing familiar methods such as send, transfer, and approve -- just as with any standard ERC-20 token.
 

--- a/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/create-token.mdx
@@ -2,7 +2,7 @@
 
 Interchain Tokens are ERC-20 tokens that are available on [multiple blockchains](https://docs.axelar.dev/resources/testnet). They are created using the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) and can be used to transfer value between blockchains.
 
-The Interchain Token Service is deployed to `0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C` while the Interchain Token Factory is deployed to `0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`
+The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66)
 
 Let's explore two methods to create new Interchain Token(s).
 
@@ -56,7 +56,19 @@ To create a custom Interchain Token:
 
 - Build your [ERC-20](https://docs.alchemy.com/docs/how-to-create-an-erc-20-token-4-steps) token and deploy it on multiple chains
 - Deploy a [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager) for existing tokens on all chains using [`deployTokenManager`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L276) on Interchain Token Service. The `deployTokenManager` method requires parameters like `salt`, `destinationChain`, `tokenManagerType`, `params`, and `gasValue`
-- Make sure the Interchain Token Service can call the mint/burn on the token and repeat the step above for other chains where the token exists using the same deployer address and salt
+- Ensure the Interchain Token Service can invoke the `mint/burn` functions on the token by calling [`transferMintership`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/utils/Minter.sol#L31) on your token. This is to transfer the minter role to ITS on all chains, enabling it to mint/burn. Repeat this step for other chains where the token exists, using the same deployer address and salt 
+
+Here is an example of how to transfer mintership:
+
+```solidity
+/**
+ * @notice Changes the minter of the contract.
+ * @dev Can only be called by the current minter.
+ * @param minter_ The address of the new minter.
+ */
+function transferMintership(address minter_) external
+```
+- Transfer Interchain Tokens between chains via the Interchain Token Service by calling the [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210)
 
 Here is an example of deploying a token manager:
 
@@ -80,8 +92,6 @@ function deployTokenManager(
     uint256 gasValue
 ) external payable 
 ```
-
-You can directly transfer tokens between chains via the Interchain Token Service by calling the [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/v1.0.0/contracts/interfaces/IInterchainTokenService.sol#L202). 
 
 Tokens can move between chains seamlessly as the Token Manager contracts will mint and burn tokens as needed. If the `minter` parameter is empty bytes when deploying a new Interchain Token, use a Mint/Burn `TokenManager`. Otherwise, use a Lock/Unlock `TokenManager`. Use the `transferMintership` on the token to change the token minter to another address.
 

--- a/src/pages/dev/send-tokens/interchain-tokens/upgrade-tokens.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/upgrade-tokens.mdx
@@ -2,7 +2,7 @@
 
 If you already have an ERC-20 token on one or more blockchains, you can turn it into an Interchain Token by deploying [Token Managers](../../reference/glossary/#token-manager). Token Managers can be either [Lock/Release](../../reference/glossary/#lockunlock) or [Mint/Burn](../../reference/glossary/#mintburn). Canonical tokens are registered under the local chain's Lock/Release token manager and mint/burn on remote chains. They can be deployed to remote chains by anyone and don't depend on a deployer address/salt.
 
-The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66). You can find the list of the deployed contract addresses to all the networks supported by Axelar [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/testnet.json).
+The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://etherscan.io/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://etherscan.io/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66).
 
 Now, let's explore how to transform existing tokens into Interchain Tokens.
 

--- a/src/pages/dev/send-tokens/interchain-tokens/upgrade-tokens.mdx
+++ b/src/pages/dev/send-tokens/interchain-tokens/upgrade-tokens.mdx
@@ -2,21 +2,19 @@
 
 If you already have an ERC-20 token on one or more blockchains, you can turn it into an Interchain Token by deploying [Token Managers](../../reference/glossary/#token-manager). Token Managers can be either [Lock/Release](../../reference/glossary/#lockunlock) or [Mint/Burn](../../reference/glossary/#mintburn). Canonical tokens are registered under the local chain's Lock/Release token manager and mint/burn on remote chains. They can be deployed to remote chains by anyone and don't depend on a deployer address/salt.
 
-The Interchain Token Service is deployed to `0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C` while the Interchain Token Factory is deployed to `0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`. You can find the list of the deployed contract addresses to all the networks supported by Axelar [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/testnet.json).
+The Interchain Token Service is deployed to [`0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C`](https://blockscan.com/address/0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C) while the Interchain Token Factory is deployed to [`0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66`](https://blockscan.com/address/0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66). You can find the list of the deployed contract addresses to all the networks supported by Axelar [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/testnet.json).
 
 Now, let's explore how to transform existing tokens into Interchain Tokens.
 
 ## Canonical Tokens (Simple wrappers)
 
-If you own an ERC-20 token on a single chain and want a wrapped, bridgeable version on other chains, register it as a [Canonical Token](../../reference/glossary/#canonical-interchain-token) with the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/v1.0.0/contracts/InterchainTokenService.sol) using the [Interchain Token Factory contract](https://github.com/axelarnetwork/interchain-token-service/blob/v1.0.0/contracts/InterchainTokenFactory.sol). Each token can only be registered a single time as a canonical chain.
+If you own an ERC-20 token on a single chain and want a wrapped, bridgeable version on other chains, register it as a [Canonical Token](../../reference/glossary/#canonical-interchain-token) with the [Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenService.sol) using the [Interchain Token Factory contract](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/InterchainTokenFactory.sol). Each token can only be registered a single time as a canonical chain.
 
 Want to try this out? [Use Remix to create your own ERC-20](https://remix.ethereum.org/axelarnetwork/axelar-docs/blob/main/public/samples/interchain-token-simple.sol) and register your token on the [Interchain Token Portal](https://testnet.interchain.axelar.dev).
 
 You can also do this directly via the `InterchainTokenService.sol` using `InterchainTokenFactory.sol` to register canonical tokens and deploy remote canonical tokens. 
 
 Follow these steps to register your token as a canonical token:
-
-- Retrieve the `tokenId` by calling the [`canonicalInterchainTokenId`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenFactory.sol#L93) with your token address
 
 - Register your token as a canonical token using the [`registerCanonicalInterchainToken`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenFactory.sol#L240) method on the `InterchainTokenFactory.sol`. This will deploy a [Lock/Release](../../reference/glossary/#lockunlock) - [Token Manager](../../reference/glossary/#token-manager) on the source chain 
 
@@ -30,7 +28,7 @@ Here is an example of registering a canonical token:
  */
 function registerCanonicalInterchainToken(address tokenAddress) external payable returns (bytes32 tokenId)
 ```
-- Deploy a remote canonical interchain token for a pre-existing token on remote chains using the [`deployRemoteCanonicalInterchainToken`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenFactory.sol#L257) method on the `InterchainTokenFactory` for each destination chain. This will create the token on each destination chain and its registered under [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager). They can be deployed to remote chains by anyone and don't depend on a deployer address/salt.
+- Deploy a remote canonical interchain token for a pre-existing token on remote chains using the [`deployRemoteCanonicalInterchainToken`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenFactory.sol#L257) method on the `InterchainTokenFactory` for each destination chain. This will create the token on each destination chain and its registered under [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager). They can be deployed to remote chains by anyone and don't depend on a deployer address/salt
 
 Here is an example of deploying a remote canonical token:
 
@@ -50,6 +48,8 @@ function deployRemoteCanonicalInterchainToken(
     uint256 gasValue
 ) external payable returns (bytes32 tokenId)
 ```
+- Approve the Interchain Token Service to spend tokens by calling the `approve` method on your token, specifying the Interchain Token Service address and the amount to be approved. Then, proceed to transfer Interchain Tokens between chains via the Interchain Token Service by calling the [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210) method
+
 
 If pre-mint is needed, you must make ERC20 approval to the Interchain Token Factory contract. When tokens are moved from the origin chain to another chain, the token will be locked on the origin chain and minted on the destination chain. If you moved tokens directly from one non-origin chain to another, the token would be burned on the source chain and minted on the destination chain.
 
@@ -59,8 +59,9 @@ If pre-mint is needed, you must make ERC20 approval to the Interchain Token Fact
 For custom functionality on multiple chains:
 
 - Deploy your [custom](../../reference/glossary/#custom-token) token on multiple chains or have existing versions on multiple chains
-- Retrieve the `tokenId` by calling the [`interchainTokenId`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L218) on Interchain Token Service with your address (deployer) and salt
-- Deploy a [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager) for existing tokens on all chains using [`deployTokenManager`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L276) on Interchain Token Service. The `deployTokenManager` method requires parameters like `salt`, `destinationChain`, `tokenManagerType`, `params`, and `gasValue`.
+- Deploy a [Mint/Burn](../../reference/glossary/#mintburn) - [Token Manager](../../reference/glossary/#token-manager) for existing tokens on all chains using [`deployTokenManager`](https://github.com/axelarnetwork/interchain-token-service/blob/9edc4318ac1c17231e65886eea72c0f55469d7e5/contracts/InterchainTokenService.sol#L276) on Interchain Token Service. The `deployTokenManager` method requires parameters like `salt`, `destinationChain`, `tokenManagerType`, `params`, and `gasValue`
+- Transfer Interchain Tokens between chains via the Interchain Token Service by calling the [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/9223108211b977d9138fdd67d5b4a641fc35c18c/contracts/interfaces/IInterchainTokenService.sol#L210)
+
 
 You can optionally have any of these custom tokens extend [`IInterchainTokenStandard`](https://github.com/axelarnetwork/interchain-token-service/blob/main/contracts/interfaces/IInterchainTokenStandard.sol) to offer [`interchainTransfer`](https://github.com/axelarnetwork/interchain-token-service/blob/a2dfcb2490497e627b66be789d944ec3260c5eea/contracts/interfaces/IInterchainTokenStandard.sol#L20) and [`interchainTransferFrom`](https://github.com/axelarnetwork/interchain-token-service/blob/a2dfcb2490497e627b66be789d944ec3260c5eea/contracts/interfaces/IInterchainTokenStandard.sol#L37) methods directly on your token.
 


### PR DESCRIPTION
- Add hyperlinks to ITS and Factory addresses on Blockscan
- Add what next after deploying the interchain token, which is to do an interchain transfer
- Add a step to approve ITS after deploying canonical token before doing ITS transfer
- Remove the tokenID retrieval step where it's not required
- Add steps to give permission to ITS on all chains before doing interchain transfer for pre-existing token
