### PR TITLE
fix: evm assets not appearing in docs

### DIFF
--- a/src/data/evm_assets.json
+++ b/src/data/evm_assets.json
@@ -3672,7 +3672,7 @@
           "transfer_fee": 0.1
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x254d06f33bDc5b8ee05b2ea472107E300226659A",
           "symbol": "aUSDC",
           "decimals": 6,
@@ -3799,7 +3799,7 @@
           "transfer_fee": 0.1
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x23ee2343B892b1BB63503a4FAbc840E0e2C6810f",
           "symbol": "wAXL",
           "decimals": 6,
@@ -3977,7 +3977,7 @@
           "transfer_fee": 7e-05
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0xeA700DCe55e72C4C08b97AcFc7dF214EC30F4a64",
           "symbol": "axlWETH",
           "decimals": 18,
@@ -4104,7 +4104,7 @@
           "transfer_fee": 0.07
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x21ba4f6aEdA155DD77Cc33Fb93646910543F0380",
           "symbol": "WMATIC",
           "decimals": 18,
@@ -4231,7 +4231,7 @@
           "transfer_fee": 0.001
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x2a87806561C550ba2dA9677c5323413E6e539740",
           "symbol": "WAVAX",
           "decimals": 18,
@@ -4358,7 +4358,7 @@
           "transfer_fee": 0.08
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x594D8b81eC765410536ab59E98091700b99508D8",
           "symbol": "WFTM",
           "decimals": 18,
@@ -4485,7 +4485,7 @@
           "transfer_fee": 0.0003
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0xA9A2D8F279ABC436a18DBB1df3FB233039935D0A",
           "symbol": "WBNB",
           "decimals": 18,
@@ -4612,7 +4612,7 @@
           "transfer_fee": 0.04
         },
         {
-          "chain": "sepolia",
+          "chain": "ethereum-sepolia",
           "address": "0x4B13D583F45Aa01fb2bE18a7AAfE14DE183B1Ac9",
           "symbol": "WDEV",
           "decimals": 18,


### PR DESCRIPTION
fix for prod issue of assets not appearing in docs
NOTE: chain name is ethereum-sepolia, not sepolia.

Fix: #698 