### PR TITLE
Add Bonadocs Widget to doc pages for improved interactivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/mdx": "^1.1.0",
         "@astrojs/react": "^3.0.2",
         "@astrojs/sitemap": "^3.0.0",
+        "@bonadocs/widget": "^1.0.2",
         "@headlessui/react": "^1.7.2",
         "@redux-devtools/extension": "^3.2.3",
         "@typeform/embed-react": "^1.21.0",
@@ -754,6 +755,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bonadocs/widget": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bonadocs/widget/-/widget-1.0.2.tgz",
+      "integrity": "sha512-sGVbXhYGZUkkIMEeRRX3BjDFXLGXAIV7pcE6xuPiD/NGUCeUTaqid+WS1vTfhphQ+J+uE1KR4noO/wxN3FVrQQ==",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/@csstools/postcss-cascade-layers": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/mdx": "^1.1.0",
     "@astrojs/react": "^3.0.2",
     "@astrojs/sitemap": "^3.0.0",
+    "@bonadocs/widget": "^1.0.2",
     "@headlessui/react": "^1.7.2",
     "@redux-devtools/extension": "^3.2.3",
     "@typeform/embed-react": "^1.21.0",

--- a/src/pages/dev/general-message-passing/gas-services/increase-gas.mdx
+++ b/src/pages/dev/general-message-passing/gas-services/increase-gas.mdx
@@ -1,3 +1,5 @@
+import BonadocsWidget from '@bonadocs/widget'
+
 # Increase Gas
 
 On occasion the prepaid gas to the Gas Receiver contract could be insufficient, such as when the destination chain is congested with transfers. When this happens, the application can resubmit a new amount of gas to pay for the transaction through [Axelarscan](http://axelarscan.io), the [AxelarJS SDK](https://docs.axelar.dev/dev/axelarjs-sdk/intro), or via a direct invocation of the [`AxelarGasService` contract](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/ad37802dc6d62fff3ab589f2605f7a3e566977dd/contracts/interfaces/IAxelarGasService.sol).
@@ -16,13 +18,8 @@ In Solidity, `addNativeGas()` takes the following parameters:
 - `logIndex` — The log index for the cross-chain call
 - `refundAddress`  — The address where refunds, if any, should be sent
 
-```solidity
-function addNativeGas(
-    bytes32 txHash,
-    uint256 logIndex,
-    address refundAddress
-) external payable override;
-```
+
+<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="GasService" functionKey="addNativeGas(bytes32,uint256,address)" />
 
 In JavaScript or TypeScript, the SDK [abstracts a method that can be invoked directly in a web application](https://docs.axelar.dev/dev/axelarjs-sdk/tx-status-query-recovery#21-native-gas-payment).
 
@@ -39,15 +36,8 @@ In Solidity, `addGas()` takes the following parameters:
 - `gasFeeAmount` — The amount of tokens to add as gas
 - `refundAddress` — The address where refunds, if any, should be sent
 
-```solidity
-function addGas(
-    bytes32 txHash,
-    uint256 logIndex,
-    address gasToken,
-    uint256 gasFeeAmount,
-    address refundAddress
-) external override;
-```
+
+<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="GasService" functionKey="addGas(bytes32,uint256,address,uint256,address)" />
 
 In JavaScript or TypeScript, the SDK [abstracts a method that can be invoked directly in a web application](https://docs.axelar.dev/dev/axelarjs-sdk/tx-status-query-recovery#22-erc-20-gas-payment). It is similar to a native gas payment, except with Axelar-supported ERC-20 tokens instead of native tokens. Make sure that the ERC-20 tokens you use are supported by Axelar.
 

--- a/src/pages/dev/general-message-passing/gmp-messages.mdx
+++ b/src/pages/dev/general-message-passing/gmp-messages.mdx
@@ -1,3 +1,5 @@
+import BonadocsWidget from '@bonadocs/widget'
+
 # Call a contract on chain B from chain A
 
 import { Callout } from "/src/components/callout"
@@ -24,13 +26,8 @@ To call a contract on chain B from chain A, the user needs to call `callContract
 
 If you want to try this out directly on the blockchain, you can [use Remix to try out Axelar's GMP](https://remix.ethereum.org/axelarnetwork/axelar-docs/blob/main/public/samples/gmp-senderreceiver.sol).
 
-```solidity
-function callContract(
-    string memory destinationChain,
-    string memory contractAddress,
-    bytes memory payload
-) external;
-```
+
+<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="Gateway" functionKey="callContract(string,string,bytes)" />
 
 `AxelarExecutable` has an `execute` function that will be triggered by the Axelar network on the destination chain after the `callContract` function has been executed on the source chain. This will validate the contract call and then invoke *your* `_execute` method, where you should write any custom logic.
 

--- a/src/pages/dev/general-message-passing/gmp-tokens-with-messages.mdx
+++ b/src/pages/dev/general-message-passing/gmp-tokens-with-messages.mdx
@@ -1,3 +1,4 @@
+import BonadocsWidget from '@bonadocs/widget'
 
 # Call a contract on chain B from chain A and attach some tokens
 
@@ -27,15 +28,8 @@ To call chain B from chain A and send some tokens along the way, the user needs 
 
 As per the snippet below:
 
-```solidity
-function callContractWithToken(
-    string memory destinationChain,
-    string memory contractAddress,
-    bytes memory payload,
-    string memory symbol,
-    uint256 amount
-) external;
-```
+
+<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="Gateway" functionKey="callContractWithToken(string,string,bytes,string,uint256)" />
 
 `AxelarExecutable` has an `executeWithToken` function that will be triggered by the Axelar network on the destination chain after the `callContractWithToken` function has been executed on the source chain. This will validate the contract call and then invoke *your* `_executeWithToken` method, where you should write any custom logic.
 

--- a/src/pages/dev/send-tokens/overview.mdx
+++ b/src/pages/dev/send-tokens/overview.mdx
@@ -1,3 +1,5 @@
+import BonadocsWidget from '@bonadocs/widget'
+
 # Send tokens cross-chain
 
 There are three ways to transfer tokens cross-chain with Axelar:
@@ -8,7 +10,7 @@ There are three ways to transfer tokens cross-chain with Axelar:
 
 ## Call `sendToken`
 
-`sendToken` is an API method that allows you to send any token supported directly on the Axelar network to any recipient on a destination chain. 
+`sendToken` is an API method that allows you to send any token supported directly on the Axelar network to any recipient on a destination chain.
 
 The underlying mechanics work slightly differently, depending on whether the origin chain is an EVM chain or a Cosmos-based chain:
 
@@ -24,14 +26,8 @@ Axelar Gateways are application-layer smart contracts established on source and 
 
 An Axelar Gateway implements the `IAxelarGateway` interface, which has a public method called `sendToken`:
 
-```solidity
-function sendToken(
-    string memory destinationChain,
-    string memory destinationAddress,
-    string memory symbol,
-    uint256 amount
-) external;
-```
+
+<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="Gateway" functionKey="sendToken(string,string,string,uint256)" />
 
 #### 2. Execute approve on the source chain (ERC-20)
 


### PR DESCRIPTION
## Intro

The goal of this PR is to supercharge Axelar's documentation by adding interactive widgets that make it possible to interact with the protocol contracts directly inside the documentation. This results in better developer experience (DX) leading to an increase in protocol and app integrations for Axelar.

Demo: https://www.loom.com/share/3e0a9cfcd0fe4337b15bc7610cea2403

## Contributors

@staa99 and @Atanda1 are current and former contributors to other web3 products and tools including Infura, The Graph, and Ethers.

## Outline

When reading the documentation, the explanation of the protocol contracts is great. However, developers have to setup a basic testing environment to interact with the contracts to better understand the behavior. The widget eliminates this by enabling developers to interact with the contract methods directly within the documentation. This greatly reduces integration time and the context switching that would otherwise be required, making Axelar more developer-friendly.

We are looking to integrate the widget in the documentation pages through open source contributions. The widget will replace the function code sections with an interactive interface that enables developers to interact with the protocol function being described. In some of the guides, there are descriptions of workflows that involve a more involved operation than simply calling a single contract function. Adding the widget to such guides will help developers understand the docs better.

## Technical Information

The widget is an open-source library: [@bonadocs/widget](https://www.npmjs.com/package/@bonadocs/widget).

The list of protocol smart contracts, deployment addresses, ABIs, and other widget configuration are stored on IPFS at the URI `ipfs://bafkreib3rg6fnaq3j33js7zkoc67wn6lwtyltkw2rz2xxjs4fjgo4bdgwu`. We chose to store the data on IPFS to guarantee immutability of the contract information and addresses, preserving the safety of the widget.

## Summary of Changes

We installed the widget using

```bash
    npm install @bonadocs/widget
```

On pages where solidity functions are described, we replaced the static code block with the widget. For example, the `callContract` function looks like this:

```markdown    
<BonadocsWidget client:only widgetConfigUri="ipfs://bafkreiffnktusdlkv5pcfeorotyc7gf6l3oj2m6fz5qpq2pou25jnx4htu" contract="Gateway" functionKey="callContract(string,string,bytes)" />
```
The `widgetConfigUri` property specifies the configuration for the widget. `contract` specifies the name of the contract as defined in the linked collection from the widget config, and `functionKey` specifies the function being described.

P.S: This contribution is sponsored by \[Arbitrum X Questbook grant\](https://www.questbook.app/dashboard/?grantId=0x706bc8efecb6002f00a052fe5688d0eb89ea45f4&chainId=10&proposalId=0x463&role=builder) through \[Bonadocs\](https://github.com/bonadocs) - \[Consensys Fellowship startup\](https://consensys.io/blog/introducing-the-first-cohort-of-the-consensys-fellowship-program-for-web3).