### PR TITLE
refactor: rename testnet-1 to testnet

### DIFF
--- a/src/pages/dev/reference/testnet-contract-addresses.mdx
+++ b/src/pages/dev/reference/testnet-contract-addresses.mdx
@@ -1,7 +1,7 @@
 import EVMChains from "../../../components/evm/chains";
 import EVMAssets from "../../../components/evm/assets";
 
-# Chain names: Testnet-1 (Lisbon)
+# Chain names: Testnet (Lisbon)
 
 <div className="space-y-1 mt-4">
   ### EVM Chains

--- a/src/pages/resources/testnet/upgrades/v17.mdx
+++ b/src/pages/resources/testnet/upgrades/v17.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.17
+# Testnet upgrade: v0.17
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v18.mdx
+++ b/src/pages/resources/testnet/upgrades/v18.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.18
+# Testnet upgrade: v0.18
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v19.mdx
+++ b/src/pages/resources/testnet/upgrades/v19.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.19
+# Testnet upgrade: v0.19
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v20.mdx
+++ b/src/pages/resources/testnet/upgrades/v20.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.20
+# Testnet upgrade: v0.20
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v21.mdx
+++ b/src/pages/resources/testnet/upgrades/v21.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.21
+# Testnet upgrade: v0.21
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v22.mdx
+++ b/src/pages/resources/testnet/upgrades/v22.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.22
+# Testnet upgrade: v0.22
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v23.mdx
+++ b/src/pages/resources/testnet/upgrades/v23.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.23
+# Testnet upgrade: v0.23
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v24.mdx
+++ b/src/pages/resources/testnet/upgrades/v24.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.24
+# Testnet upgrade: v0.24
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v25.mdx
+++ b/src/pages/resources/testnet/upgrades/v25.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.25
+# Testnet upgrade: v0.25
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v26.mdx
+++ b/src/pages/resources/testnet/upgrades/v26.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.26
+# Testnet upgrade: v0.26
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v27.mdx
+++ b/src/pages/resources/testnet/upgrades/v27.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.27
+# Testnet upgrade: v0.27
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v28.mdx
+++ b/src/pages/resources/testnet/upgrades/v28.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.28
+# Testnet upgrade: v0.28
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v29.mdx
+++ b/src/pages/resources/testnet/upgrades/v29.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.29
+# Testnet upgrade: v0.29
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v31.mdx
+++ b/src/pages/resources/testnet/upgrades/v31.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.31
+# Testnet upgrade: v0.31
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v32.mdx
+++ b/src/pages/resources/testnet/upgrades/v32.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.32
+# Testnet upgrade: v0.32
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v33.mdx
+++ b/src/pages/resources/testnet/upgrades/v33.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.33
+# Testnet upgrade: v0.33
 
 import { Callout } from "/src/components/callout"
 

--- a/src/pages/resources/testnet/upgrades/v34.mdx
+++ b/src/pages/resources/testnet/upgrades/v34.mdx
@@ -1,4 +1,4 @@
-# Testnet-1 upgrade: v0.34
+# Testnet upgrade: v0.34
 
 import { Callout } from '/src/components/callout'
 


### PR DESCRIPTION
Testnet-2 was removed a while ago, rename testnet-1 to testnet to reduce confusion