### PR TITLE
chore: update `estimateGasFee` doc

### DIFF
--- a/src/pages/dev/axelarjs-sdk/axelar-query-api.mdx
+++ b/src/pages/dev/axelarjs-sdk/axelar-query-api.mdx
@@ -26,9 +26,9 @@ This is a useful query for GMP transactions, when invoking `callContract` or `ca
 
 IMPORTANT NOTES:
 
-* You must ensure the correct `gasLimit` is used for your gas estimation. The `gasLimit` parameter can be used here to override the default 700K gas limit that is used. 
+* You must ensure the correct `gasLimit` is used for your gas estimation. The `gasLimit` parameter can be used here to override the default 700K gas limit that is used.
 * The `minGasPrice` and `gasMultipler` parameters can be adjusted to enhance execution certainty of cross-chain transactions.
-* The response to the method gives a single value (in `wei`) of the total estimated gas required for the cross-chain call. In the GMPParams parameter, there is an option to show a full breakdown of fees instead by specifying `true` for `showDetailedFees`. If you do this, you will have to add the individual components of the fees yourself, 
+* The response to the method gives a single value (in `wei`) of the total estimated gas required for the cross-chain call. In the GMPParams parameter, there is an option to show a full breakdown of fees instead by specifying `true` for `showDetailedFees`. If you do this, you will have to add the individual components of the fees yourself,
   e.g. `(baseFee + executionFeeWithMultiplier)` for regular way GMP calls, or `(baseFee + executionFeeWithMultiplier + expressFee)` for GMP Express calls
 ```ts
 
@@ -58,7 +58,8 @@ IMPORTANT NOTES:
    * @param destinationChainId
    * @param sourceChainTokenSymbol
    * @param gasLimit An estimated gas amount required to execute `executeWithToken` function. The default value is 700000 which should be sufficient for most transactions.
-   * @param gasMultiplier A multiplier used to create a buffer above the calculated gas fee, to account for potential slippage throughout tx execution, e.g. 1.1 = 10% buffer. supports up to 3 decimal places
+   * @param gasMultiplier (Optional) A multiplier used to create a buffer above the calculated gas fee, to account for potential slippage throughout tx execution, e.g. 1.1 = 10% buffer. supports up to 3 decimal places
+   * The default value is "auto", which uses the `execute_gas_multiplier` from the fee response.
    * @param minGasPrice (Optional) A minimum value, in wei, for the gas price on the destination chain that is used to override the estimated gas price if it falls below this specified value.
    * @param gmpParams (Optional) Additional parameters for GMP transactions, including the ability to see a detailed view of the fee response
    * @returns
@@ -67,11 +68,11 @@ IMPORTANT NOTES:
     sourceChainId: EvmChain | string,
     destinationChainId: EvmChain | string,
     sourceChainTokenSymbol: GasToken | string,
-    gasLimit: number = DEFAULT_ESTIMATED_GAS,
-    gasMultiplier = 1.1,
+    gasLimit: number,
+    gasMultiplier = 'auto',
     minGasPrice = "0",
     gmpParams?: GMPParams
-  ): Promise<string | AxelarQueryAPIFeeResponse> 
+  ): Promise<string | AxelarQueryAPIFeeResponse>
 ```
 
 #### getTransferFee
@@ -114,7 +115,7 @@ public async getFeeForChainAndAsset(
 
 #### getDenomFromSymbol
 
-Get the denom for an asset given its symbol on a chain. For all the assets that Axelar supports natively, the network identifies the asset by a `denom`, while most EVM chains have a `symbol` for the asset. 
+Get the denom for an asset given its symbol on a chain. For all the assets that Axelar supports natively, the network identifies the asset by a `denom`, while most EVM chains have a `symbol` for the asset.
 
 The method below allows you to translate the asset symbol (as identified on an EVM chain) to the underlying denom.
 
@@ -146,7 +147,7 @@ For example, let's say you have Axelar's canonical testnet `aUSDC`. The symbol f
 
 #### getSymbolFromDenom
 
-Get the symbol for an asset on a given chain given its denom. For all the assets that Axelar supports natively, the network identifies the asset by a `denom`, while most EVM chains have a `symbol` for the asset. 
+Get the symbol for an asset on a given chain given its denom. For all the assets that Axelar supports natively, the network identifies the asset by a `denom`, while most EVM chains have a `symbol` for the asset.
 
 The method below allows you to translate the asset denom to the asset symbol (as identified on an EVM chain).
 


### PR DESCRIPTION
# Description

[AXE-3184](https://axelarnetwork.atlassian.net/browse/AXE-3184)

This PR updates the `estimateGasFee` usage to the latest version of `axelarjs-sdk` (v0.14.1).

[AXE-3184]: https://axelarnetwork.atlassian.net/browse/AXE-3184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ