### PR TITLE
fix: add info to Express docs

### DIFF
--- a/src/layouts/navigation.ts
+++ b/src/layouts/navigation.ts
@@ -76,10 +76,6 @@ export const getNavigation = (section) => {
               href: "/dev/general-message-passing/gmp-tokens-with-messages",
             },
             {
-              title: "Express",
-              href: "/dev/general-message-passing/express",
-            },
-            {
               title: "Monitor Transaction State",
               href: "/dev/general-message-passing/monitoring",
             },
@@ -116,6 +112,10 @@ export const getNavigation = (section) => {
                   href: "/dev/general-message-passing/developer-guides/example-gmp",
                 },
               ],
+            },
+            {
+              title: "Express Service",
+              href: "/dev/general-message-passing/express",
             },
           ],
         },

--- a/src/pages/dev/general-message-passing/express.mdx
+++ b/src/pages/dev/general-message-passing/express.mdx
@@ -23,7 +23,7 @@ To onboard your app to the Express Service:
 
 ### Required onboarding information
 
-The following information is required for an Express relayer to be configured for your protocol:
+The following information is required for an Express relayer to be configured for your app:
 
 1. The address of the contract integrating with Express
 2. The assets (tokens) to be sent in Express transactions from that contract

--- a/src/pages/dev/general-message-passing/express.mdx
+++ b/src/pages/dev/general-message-passing/express.mdx
@@ -1,26 +1,29 @@
-# Introduction to the Express Service
+# Introduction to the Axelar Express Service
 
-Axelar's Express Service allows interchain [GMP](https://docs.axelar.dev/dev/general-message-passing/overview) transactions to execute significantly more quickly than regular GMP transactions. 
+Axelar's Express Service allows interchain [GMP](/dev/general-message-passing/overview) transactions to execute significantly more quickly than regular GMP transactions. 
 
-Axelar requires a GMP transaction to be finalized on the source chain before it can be executed on the destination chain. Some source chains have a long [transaction time](https://docs.axelar.dev/learn/txduration), taking up to 80 minutes to achieve finality.
+Axelar requires a GMP transaction to be finalized on the source chain before it can be executed on the destination chain. Some source chains have a long [transaction time](/learn/txduration), taking up to 80 minutes to achieve finality.
 
 The Express Service skips this wait time by executing the transaction on the destination chain before the source chain transaction is completely finalized. The following are two example transactions that took place between the Linea and Polygon chains:
 
-* [Express transaction](https://axelarscan.io/gmp/0x4dbf091ebf31157bf73995c0fb473f115888bd1f11793359807d543ada03f021:11): 18 seconds transaction time
-* [Non-Express transaction](https://axelarscan.io/gmp/0xc3653cda8535c59e0418b57250c504528a493dd5556fc4cb71b80f8c0a867e62:2): 28 minutes transaction time
+* [Express transaction](https://axelarscan.io/gmp/0x4dbf091ebf31157bf73995c0fb473f115888bd1f11793359807d543ada03f021:11): **18 seconds** transaction time
+* [Non-Express transaction](https://axelarscan.io/gmp/0xc3653cda8535c59e0418b57250c504528a493dd5556fc4cb71b80f8c0a867e62:2): **28 minutes** transaction time
 
 Think of it as a loan: funds on the destination chain are "loaned out" to the app while the transaction is still being finalized on the source chain. Once the transaction is finalized on the source chain and goes through the Axelar network, the funds that are sent through the Axelar network are used to pay back the Express Relayer on the destination chain which loaned out the funds.
 
-## Integration
+## Integrate your app with the Express Service
 
-Applications integrated with Express contracts will not automatically have transactions going through the Express service. They must be onboarded by the Interop Labs team to integrate with Express. 
+**Applications integrated with Express contracts will not automatically have transactions going through the Express service.** They must be onboarded by the Interop Labs team to integrate with Express. 
 
-1. Each protocol must [provide liquidity](#funding) as insurance for the Express transaction.
-2. The contract must [inherit from either](#axelar-executable-vs-axelar-valued-express-executable) the [`AxelarExpressExecutable`](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/express/AxelarExpressExecutable.sol) or the [`AxelarValuedExpressExecutable`](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/express/AxelarValuedExpressExecutable.sol) contracts.
-3. The team must submit the required [onboarding information](#required-onboarding-information) to enable being onboarded to Axelar's Express infrastructure.
+To onboard your app to the Express Service:
 
-### Required Onboarding Information
-The following information is required for an Express Relayer to be configured for your protocol:
+1. Provide [liquidity](#funding) as insurance for the Express transaction.
+2. Have your app contract [inherit](#axelar-executable-vs-axelar-valued-express-executable) from either the [`AxelarExpressExecutable`](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/express/AxelarExpressExecutable.sol) or the [`AxelarValuedExpressExecutable`](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/express/AxelarValuedExpressExecutable.sol) contracts.
+3. Fill out and submit the [required onboarding information](#required-onboarding-information) through the [Axelar Express Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSeIpbcdEzQQY0k00leK2jrOnR0KUUJlKc2SzeNzENyLWs80jA/viewform).
+
+### Required onboarding information
+
+The following information is required for an Express relayer to be configured for your protocol:
 
 1. The address of the contract integrating with Express
 2. The assets (tokens) to be sent in Express transactions from that contract
@@ -28,9 +31,10 @@ The following information is required for an Express Relayer to be configured fo
     - The maximum value to be Expressed in a 30-minute window
 3. The EVM chains to be enabled for Express transactions
 
-Please complete this [form](https://docs.google.com/forms/d/e/1FAIpQLSeIpbcdEzQQY0k00leK2jrOnR0KUUJlKc2SzeNzENyLWs80jA/viewform) to provide the required information.
+Please provide this information via the [Axelar Express Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSeIpbcdEzQQY0k00leK2jrOnR0KUUJlKc2SzeNzENyLWs80jA/viewform).
 
 ## Axelar Executable vs. Axelar Valued Express Executable
+
 Regular Express Executables have tokens being sent with them. With the Valued Express Executable, the relayer is able to calculate the value of a GMP message in the event that the message itself has a value with no tokens being sent.
 
 If your app requires Express support for arbitrary GMP messages, where the value of the payload can alter the state of the contract, you can use the Valued Express Executable. Call either the `contractCallWithTokenValue()` or `callContractValue()` function to trigger your interchain transaction. These functions will return the value that the call is worth.
@@ -42,16 +46,19 @@ Under the hood, the relayer dynamically queries the value of the payload from th
 Protocols that integrate with the Valued Express Executable must keep the following in mind:
 
 1. They must be whitelisted, since the relayer cannot trust arbitrary contracts.
-2. The value of the payload in terms of a token is not state or time dependent, so the value cannot change between the time the call is triggered on the source chain and when it is executed on the destination chain. This restriction can be removed, but since it will require the relayer to assume more risk, there will be an additional fee involved.
+2. The value of the payload in terms of a token is not state or time dependent, so the value cannot change between the time the call is triggered on the source chain and when it is executed on the destination chain. This restriction can be removed, but since it will require the relayer to assume more risk, there will be an [additional fee](#fees) involved.
 
 
-## Interchain Token Service (ITS) 
-Interchain Tokens that were deployed via the [Interchain Token Service](https://axelar.network/its), can also be integrated to the Express Service. After integration, the ITS token will use `AxelarValuedExpressExecutable` instead of `AxelarValuedExecutable`, as the value in an ITS transaction is in the payload.
+## Express ITS tokens
+
+Interchain Tokens that were deployed via the [Interchain Token Service](https://axelar.network/its) can also be integrated with the Express Service. After integration, an ITS token will use `AxelarValuedExpressExecutable` instead of `AxelarValuedExecutable`, as the value in an ITS transaction is in the payload.
 
 ## Fees
-Express transactions require an additional [fee](https://docs.axelar.dev/dev/reference/pricing#callcontractwithtokenexpress-gmp-express) alongside existing GMP fees. This extra fee goes to the Express Relayer for assuming the risk of an Express transaction. If the fee is not paid then the transaction will revert to a regular non-express GMP transaction. This fee is currently set to $1 per call.
 
-### Gas Estimation
+Express transactions require an [additional fee](/dev/gas-service/pricing#callcontractwithtokenexpress-gmp-express) of **$1 USD per call** alongside existing GMP fees. This extra fee acts as insurance for the Express relayer for assuming the risk of an Express transaction. If the fee is not paid, the transaction will revert to a regular non-Express GMP transaction.
+
+### Estimate gas costs for an Express transaction
+
 The [`estimateGasFee()`](https://docs.axelar.dev/dev/axelarjs-sdk/axelar-query-api#estimategasfee) function provides the estimated cost when estimating gas for an interchain transaction. This same function can be used to estimate gas costs for an Express transaction. You'll just need to provide some more information to help it specify an accurate gas estimation.
 
 For example, in an Express transaction from Polygon to Avalanche:
@@ -76,11 +83,22 @@ await api.estimateGasFee(
 
 ## Risks
 
+Using the Axelar Express Service comes with risks. Please keep these in mind when integrating your contracts.
+
 ### Funding
-Using Axelar Express comes with risks. Namely if anything changes on the source chain from the time the transaction is sent to the time it is finalized (due to a [block reorg](https://cointelegraph.com/explained/what-is-chain-reorganization-in-blockchain-technology) for example) and the transaction on the destination chain has already executed then that could lead to lost funds. These funds would be lost as the transaction will have been instantly executed on the destination chain on the assumption of logic that never took place on the source chain. Due to the potential risk here, liquidity must be provided for the Express Relayers by a party to assume the risk that the relayer is taking when it loans out funds on the destination chain.
 
-### Execution
-On the destination chain an Axelar relayer triggers the `_execute()`/ `_executeWithToken()` function to trigger a transaction. The GMP payload being used can be assumed to be true as it passes through the [validation process](https://github.com/axelarnetwork/axelar-cgp-solidity/blob/4d01eb6ea1b5413520d9ecab804f815103021148/contracts/AxelarGateway.sol#L233) on the Axelar Gateway. In an express call however the execution on the destination chain occurs before the source chain finalizes, meaning that you cannot rely on this validation process. To mitigate, data that is being passed in you can make use of the unique [`CommandId`](https://github.com/axelarnetwork/axelar-core/blob/main/docs/cli/axelard_query_evm_command.md). The `CommandId` is a unique identifier, which is available on the destination chain you're transacting to. With your unique commanId you can reconstruct the message that was passed in. 
+Since the Express service instantly executes the transaction on the destination chain, any changes on the source chain between the time the transaction is sent and the time it is finalized (for example, due to a [block reorg](https://cointelegraph.com/explained/what-is-chain-reorganization-in-blockchain-technology)) could lead to funds being lost.
 
-## Example
-To see how to execute with Axelar Express at the contract level follow this example, see the [the Call Contract with Token (Express) sample contract](https://github.com/axelarnetwork/axelar-examples/tree/main/examples/evm/call-contract-with-token-express). The implementation is very similar to a regular Axelar GMP integration, however notice that the contract is inherting from `AxelarExpressExecutable` rather than `AxelarExecutable`.
+These funds would be lost because the transaction will have been instantly executed on the destination chain on the assumption of logic that never took place on the source chain.
+
+To mitigate this risk, the transacting party must provide liquidity to the Express relayers for all Express transactions. This liquidity will act as insurance against the risk the relayer takes when loaning out funds on the destination chain. The amount of funds should match the value of the transaction itself, and will be returned when the transaction has finalized on the source chain.
+
+### Payload validity during execution
+
+In a non-Express transaction, an Axelar relayer triggers a transaction with either the `execute()` or `executeWithToken()` function. The GMP payload can be assumed to be true as it passes through the [validation process](https://github.com/axelarnetwork/axelar-cgp-solidity/blob/4d01eb6ea1b5413520d9ecab804f815103021148/contracts/AxelarGateway.sol#L233) on the Axelar Gateway. However, in an Express call, the execution on the destination chain occurs before the source chain finalizes. Thus, you cannot rely on the validation process.
+
+Instead, use the [`commandID`](https://github.com/axelarnetwork/axelar-core/blob/main/docs/cli/axelard_query_evm_command.md), the transaction’s unique identifier on the destination chain, to reconstruct the message that was passed in.
+
+## Sample contract using Express
+
+The [Call Contract with Token (Express) sample contract](https://github.com/axelarnetwork/axelar-examples/tree/main/examples/evm/call-contract-with-token-express) is an example of a contract that executes with the Express Service. The implementation is an Axelar GMP integration that inherits from `AxelarExpressExecutable` rather than `AxelarExecutable`.

--- a/src/pages/dev/general-message-passing/express.mdx
+++ b/src/pages/dev/general-message-passing/express.mdx
@@ -13,7 +13,7 @@ Think of it as a loan: funds on the destination chain are "loaned out" to the ap
 
 ## Integrate your app with the Express Service
 
-**Applications integrated with Express contracts will not automatically have transactions going through the Express service.** They must be onboarded by the Interop Labs team to integrate with Express. 
+**Your application must be onboarded by the Interop Labs team to integrate with Express.** Simply extending the `AxelarExpressExecutable` or `AxelarValuedExpressExecutable` contracts is not enough.
 
 To onboard your app to the Express Service:
 
@@ -91,7 +91,7 @@ Since the Express service instantly executes the transaction on the destination 
 
 These funds would be lost because the transaction will have been instantly executed on the destination chain on the assumption of logic that never took place on the source chain.
 
-To mitigate this risk, the transacting party must provide liquidity to the Express relayers for all Express transactions. This liquidity will act as insurance against the risk the relayer takes when loaning out funds on the destination chain. The amount of funds should match the value of the transaction itself, and will be returned when the transaction has finalized on the source chain.
+To mitigate this risk, liquidity must be provided to the Express relayers for all Express transactions. This liquidity will act as insurance against the risk the relayer takes when loaning out funds on the destination chain. The amount of funds should match the value of the transaction itself, and will be returned when the transaction has finalized on the source chain.
 
 ### Payload validity during execution
 


### PR DESCRIPTION
- Added info about Express transaction liquidity being equivalent to the value of the transaction itself
- Re-organized and reworded some content for clarity
- Moved the doc to be last in the GMP section, for differentiation purposes

Preview: https://axelar-docs-git-marty-express-gmp-capital-axelar-network.vercel.app/dev/general-message-passing/express