### PR TITLE
Update Arbitrum External Chain Maintainer Documents

### DIFF
--- a/src/pages/validator/external-chains/arbitrum.mdx
+++ b/src/pages/validator/external-chains/arbitrum.mdx
@@ -43,12 +43,12 @@ Please provide the RPC URL of your synced [Ethereum node](ethereum) with this fl
 <tabs>
   <tab-item title="Mainnet">
   ```bash
-  docker run --rm -it -d -v /path/to/data/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 <LATEST_DOCKER_IMAGE> --l1.url <YOUR_ETH_RPC_URL> --l2.chain-id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"
+  docker run --rm -it -d -v /path/to/data/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 <LATEST_DOCKER_IMAGE> --parent-chain.connection.url=<YOUR_ETH_RPC_URL> --parent-chain.blob-client.beacon-url=<YOUR_BEACON_CHAIN_RPC_URL> --chain.id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"
   ```
   </tab-item>
   <tab-item title="Goerli Testnet">
   ```bash
- docker run --rm -it -d -v /path/to/data/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 <LATEST_DOCKER_IMAGE> --l1.url <YOUR_GOERLI_ETH_RPC_URL> --l2.chain-id=421613 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
+ docker run --rm -it -d -v /path/to/data/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 <LATEST_DOCKER_IMAGE> --parent-chain.connection.url=<YOUR_GOERLI_ETH_RPC_URL> --parent-chain.blob-client.beacon-url=<YOUR_BEACON_CHAIN_RPC_URL> --chain.id=421613 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
   ```
   </tab-item>
 </tabs>


### PR DESCRIPTION
As of versions past v2.1.0, the flag `--l1.url` becomes `--parent-chain.connection.url` and the flag `--l2.chain.id` becomes `--chain.id`. 

Additionally a new flag `--parent-chain.blob-client.beacon-url` is introduced. 

Documentation for these changes being made is available here: https://docs.arbitrum.io/node-running/how-tos/running-a-full-node#required-parameters. These changes should apply to all Axelar validators.