### PR TITLE
fix: improve mobile nav usability

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -106,7 +106,8 @@ const shownDescription = description || 'The Axelar Documentation tells you how 
       </a>
       </div>
       <div class="mobile" id="menu">
-          <svg fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><title>menu</title><path d="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z" /></svg>
+          <svg id="menu-open" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><title>menu</title><path d="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z" /></svg>
+          <svg id="menu-close" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32"><title>close-thick</title><path d="M20 6.91L17.09 4L12 9.09L6.91 4L4 6.91L9.09 12L4 17.09L6.91 20L12 14.91L17.09 20L20 17.09L14.91 12L20 6.91Z" /></svg>
       </div>
     </nav>
     <div id="search-results"></div>

--- a/src/scripts/menu.ts
+++ b/src/scripts/menu.ts
@@ -1,3 +1,5 @@
 document.getElementById("menu").addEventListener("click", function () {
+  document.getElementById("menu").classList.toggle("open");
   document.querySelector(".sideNav").classList.toggle("show");
+  document.querySelector("article").classList.toggle("nomobile");
 });

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -720,13 +720,26 @@ astro-island button {
     justify-content: right;
     display: flex;
   }
+  #menu #menu-open {
+    display: block;
+  }
+  #menu #menu-close {
+    display: none;
+  }
+  #menu.open #menu-open {
+    display: none;
+  }
+  #menu.open #menu-close {
+    display: block;
+  }
+
   .sideNav {
     display: none;
   }
   .sideNav.show {
     position: absolute;
     display: block;
-    background-color: #ccc;
+    background-color: #fff;
     top: 64px;
     left: 8px;
     width: calc(100% - 16px);


### PR DESCRIPTION
This changes the mobile menu behavior to hide article content while the menu is open, per the standards set by Astro and OpenZeppelin, among many others.

Fixes #501