### PR TITLE
[bugfix]: All Assets table

### DIFF
--- a/src/components/evm/assets.jsx
+++ b/src/components/evm/assets.jsx
@@ -161,7 +161,11 @@ export default ({ environment = "mainnet" }) => {
                           </div>
                         </div>
                       ) : c.id === "denom" ? (
-                        <div className="flex items-center text-base space-x-1.5">
+                        <div
+                          className={`flex items-center text-base space-x-1.5 ${
+                            id.length > 15 ? "wrap-text" : ""
+                          }`}
+                        >
                           <span className="whitespace-nowrap text-base font-semibold">
                             {id}
                           </span>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -693,6 +693,10 @@ astro-island button {
   display: none;
 }
 
+.wrap-text {
+  word-break: break-word;
+}
+
 /* Only render TOC if we have space */
 @media (max-width: 950px) {
   #toc {


### PR DESCRIPTION
added wrapping to long denoms so that the entire table is not offset when going through all assets

As referenced here: https://github.com/axelarnetwork/axelar-docs/issues/817
