### PR TITLE
feat: clarify store vs instantiate as deployment options

### DIFF
--- a/src/pages/dev/amplifier/chain-integration.mdx
+++ b/src/pages/dev/amplifier/chain-integration.mdx
@@ -135,9 +135,9 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
 
 ### Onboard a chain to Amplifier
 
-Once you are running `ampd` and `tofnd`, you can onboard a chain to the Amplifier using the `gateway`, `voting verifier`, and `multisig prover` contracts. **This requires approval by the Interop Labs team.**
+Once you are running `ampd` and `tofnd`, you can onboard a chain to the Amplifier by instantiating the `gateway`, `voting verifier`, and `multisig prover` contracts.
 
-You can either use the existing deployed contracts and their `code id`s, or build and deploy from the `axelar-examples` repo. 
+You can either instantiate existing deployed contracts on th DevNet via their `code_id`s, or build and store these contracts from the `axelar-examples` repo.  A `code_id` is a CosmWasm identifier of a stored contract that can be instantiated.
 
 #### Option 1: Use existing deployed contracts
 
@@ -200,7 +200,17 @@ Use the existing deployments for all three contracts, making note of the existin
     ```bash
     {"height":"128925","txhash":"46622CBF0BAC046C27CB455AFEFAF9DCD8F7D89C9D6768E533F5CC17769B09F3","codespace":"","code":0,"data":"0A460A1E2F636F736D7761736D2E7761736D2E76312E4D736753746F7265436F64651224080B122098170453109EF00C5B22ED476B80411EC309E1AEE174CDD59A4A4DAB336CCDAC","raw_log":"[{\"events\":[{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmwasm.wasm.v1.MsgStoreCode\"},{\"key\":\"module\",\"value\":\"wasm\"},{\"key\":\"sender\",\"value\":\"axelar1ypt7vtlj4c67ezex8nwc0vm0acf6d6evss2dau\"}]},{\"type\":\"store_code\",\"attributes\":[{\"key\":\"code_checksum\",\"value\":\"98170453109ef00c5b22ed476b80411ec309e1aee174cdd59a4a4dab336ccdac\"},{\"key\":\"code_id\",\"value\":\"11\"}]}]}]","logs":[{"msg_index":0,"log":"","events":[{"type":"message","attributes":[{"key":"action","value":"/cosmwasm.wasm.v1.MsgStoreCode"},{"key":"module","value":"wasm"},{"key":"sender","value":"axelar1ypt7vtlj4c67ezex8nwc0vm0acf6d6evss2dau"}]},{"type":"store_code","attributes":[{"key":"code_checksum","value":"98170453109ef00c5b22ed476b80411ec309e1aee174cdd59a4a4dab336ccdac"},{"key":"code_id","value":"11"}]}]}],"info":"","gas_wanted":"8377414","gas_used":"4203516","tx":null,"timestamp":"","events":[{"type":"coin_spent","attributes":[{"key":"c3BlbmRlcg==","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1","index":true},{"key":"YW1vdW50","value":"NTg2NDJ1YW1wbGlmaWVy","index":true}]},{"type":"coin_received","attributes":[{"key":"cmVjZWl2ZXI=","value":"YXhlbGFyMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNWg0Z3F1","index":true},{"key":"YW1vdW50","value":"NTg2NDJ1YW1wbGlmaWVy","index":true}]},{"type":"transfer","attributes":[{"key":"cmVjaXBpZW50","value":"YXhlbGFyMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsNWg0Z3F1","index":true},{"key":"c2VuZGVy","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1","index":true},{"key":"YW1vdW50","value":"NTg2NDJ1YW1wbGlmaWVy","index":true}]},{"type":"message","attributes":[{"key":"c2VuZGVy","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1","index":true}]},{"type":"tx","attributes":[{"key":"ZmVl","value":"NTg2NDJ1YW1wbGlmaWVy","index":true},{"key":"ZmVlX3BheWVy","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1","index":true}]},{"type":"tx","attributes":[{"key":"YWNjX3NlcQ==","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1Lzg=","index":true}]},{"type":"tx","attributes":[{"key":"c2lnbmF0dXJl","value":"allvMWNsNUxHdC9DNkR4bGIxUG1MczJUY0VGckhNOUtGNEkybVRQVlNRUmFMcGNhdkxuRWR4ZFNBYnlnVWZFT3R2dDBtUjBhbnFoTk1Tb2ZTNnNlL1E9PQ==","index":true}]},{"type":"message","attributes":[{"key":"YWN0aW9u","value":"L2Nvc213YXNtLndhc20udjEuTXNnU3RvcmVDb2Rl","index":true}]},{"type":"message","attributes":[{"key":"bW9kdWxl","value":"d2FzbQ==","index":true},{"key":"c2VuZGVy","value":"YXhlbGFyMXlwdDd2dGxqNGM2N2V6ZXg4bndjMHZtMGFjZjZkNmV2c3MyZGF1","index":true}]},{"type":"store_code","attributes":[{"key":"Y29kZV9jaGVja3N1bQ==","value":"OTgxNzA0NTMxMDllZjAwYzViMjJlZDQ3NmI4MDQxMWVjMzA5ZTFhZWUxNzRjZGQ1OWE0YTRkYWIzMzZjY2RhYw==","index":true},{"key":"Y29kZV9pZA==","value":"MTE=","index":true}]}]}
     ```
-        
+### Option 2: Re-use existing deployed contracts
+
+Use the existing deployments for all three contracts, making note of the existing deployment's `code id`:
+    * [Gateway](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/devnet-amplifier.json#L409) (Code ID: `7`)
+    * [Voting verifier](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/devnet-amplifier.json#L370) (Code ID: `6`)
+    * [Mutisig prover](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/devnet-amplifier.json#L434) (Code ID: `8`)
+
+
+
+### Instantiate the contracts
+
 1. Instantiate the voting verifier:
 
     ```bash


### PR DESCRIPTION
Improves #897

Merge this instead of #900 if we want to still allow instantiation of existing contracts, rather than requiring rebuild.