### PR TITLE
Add Bonadocs Widget to Increase Gas Page for improved interactivity (Updated)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/mdx": "^1.1.0",
         "@astrojs/react": "^3.0.2",
         "@astrojs/sitemap": "^3.0.0",
-        "@bonadocs/widget": "^1.0.6",
+        "@bonadocs/widget": "^1.0.7",
         "@headlessui/react": "^1.7.2",
         "@redux-devtools/extension": "^3.2.3",
         "@typeform/embed-react": "^1.21.0",
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/@bonadocs/widget": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@bonadocs/widget/-/widget-1.0.6.tgz",
-      "integrity": "sha512-Y81WxUlgHt+FLAGzxiIDAAz9fJHdCPit2DjAwce+eZzbslE63w4iFSxIBsRMruYqfoxuJJJYUV3Dd4zPXfKrPQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@bonadocs/widget/-/widget-1.0.7.tgz",
+      "integrity": "sha512-JVs312/JFenZ1JWu6OrHW93YAUPleLOLjvCk/ogF6QoCMVqEqh0fYtBI3tXmIy/uZ3l9flMVuAV+uNHLchZLeA=="
     },
     "node_modules/@csstools/postcss-cascade-layers": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/mdx": "^1.1.0",
         "@astrojs/react": "^3.0.2",
         "@astrojs/sitemap": "^3.0.0",
+        "@bonadocs/widget": "^1.0.6",
         "@headlessui/react": "^1.7.2",
         "@redux-devtools/extension": "^3.2.3",
         "@typeform/embed-react": "^1.21.0",
@@ -755,6 +756,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bonadocs/widget": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@bonadocs/widget/-/widget-1.0.6.tgz",
+      "integrity": "sha512-Y81WxUlgHt+FLAGzxiIDAAz9fJHdCPit2DjAwce+eZzbslE63w4iFSxIBsRMruYqfoxuJJJYUV3Dd4zPXfKrPQ=="
     },
     "node_modules/@csstools/postcss-cascade-layers": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/mdx": "^1.1.0",
     "@astrojs/react": "^3.0.2",
     "@astrojs/sitemap": "^3.0.0",
+    "@bonadocs/widget": "^1.0.6",
     "@headlessui/react": "^1.7.2",
     "@redux-devtools/extension": "^3.2.3",
     "@typeform/embed-react": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@astrojs/mdx": "^1.1.0",
     "@astrojs/react": "^3.0.2",
     "@astrojs/sitemap": "^3.0.0",
-    "@bonadocs/widget": "^1.0.6",
+    "@bonadocs/widget": "^1.0.7",
     "@headlessui/react": "^1.7.2",
     "@redux-devtools/extension": "^3.2.3",
     "@typeform/embed-react": "^1.21.0",

--- a/src/pages/dev/gas-service/increase-gas.mdx
+++ b/src/pages/dev/gas-service/increase-gas.mdx
@@ -40,15 +40,6 @@ In Solidity, `addNativeGas()` takes the following parameters:
 
 <BonadocsWidget client:only deploymentAddresses={deploymentAddresses} functionSignature="addNativeGas(bytes32 txHash, uint256 logIndex, address refundAddress) payable" />
 
-
-```solidity
-function addNativeGas(
-    bytes32 txHash,
-    uint256 logIndex,
-    address refundAddress
-) external payable override;
-```
-
 In JavaScript or TypeScript, the SDK [abstracts a method that can be invoked directly in a web application](https://docs.axelar.dev/dev/axelarjs-sdk/tx-status-query-recovery#21-native-gas-payment).
 
 
@@ -65,16 +56,6 @@ In Solidity, `addGas()` takes the following parameters:
 - `refundAddress` — The address where refunds, if any, should be sent
 
 <BonadocsWidget client:only deploymentAddresses={deploymentAddresses} functionSignature="addGas(bytes32 txHash, uint256 logIndex, address gasToken, uint256 gasFeeAmount, address refundAddress)" />
-
-```solidity
-function addGas(
-    bytes32 txHash,
-    uint256 logIndex,
-    address gasToken,
-    uint256 gasFeeAmount,
-    address refundAddress
-) external override;
-```
 
 In JavaScript or TypeScript, the SDK [abstracts a method that can be invoked directly in a web application](https://docs.axelar.dev/dev/axelarjs-sdk/tx-status-query-recovery#22-erc-20-gas-payment). It is similar to a native gas payment, except with Axelar-supported ERC-20 tokens instead of native tokens. Make sure that the ERC-20 tokens you use are supported by Axelar.
 

--- a/src/pages/dev/gas-service/increase-gas.mdx
+++ b/src/pages/dev/gas-service/increase-gas.mdx
@@ -1,3 +1,25 @@
+import BonadocsWidget from '@bonadocs/widget'
+
+export const deploymentAddresses = new Map([
+  [42161,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [43114,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [8453,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [56,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [42220,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [2031,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [1,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [250,"0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [314, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [13371, "0x24C2b56128fF8E7bFaD578ABefB0fc7Dfa9ba358"],
+  [2222, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [59144, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [5000, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [1284, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [10, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [137, "0x2d5d7d31F671F86C782533cc367F14109a082712"],
+  [534352, "0x2d5d7d31F671F86C782533cc367F14109a082712"]
+])
+
 # Increase Gas
 
 On occasion the prepaid gas to the Gas Receiver contract could be insufficient, such as when the destination chain is congested with transfers. When this happens, the application can resubmit a new amount of gas to pay for the transaction through [Axelarscan](http://axelarscan.io), the [AxelarJS SDK](https://docs.axelar.dev/dev/axelarjs-sdk/intro), or via a direct invocation of the [`AxelarGasService` contract](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/ad37802dc6d62fff3ab589f2605f7a3e566977dd/contracts/interfaces/IAxelarGasService.sol).
@@ -15,6 +37,9 @@ In Solidity, `addNativeGas()` takes the following parameters:
 - `txHash` — The transaction hash of the cross-chain call
 - `logIndex` — The log index for the cross-chain call
 - `refundAddress`  — The address where refunds, if any, should be sent
+
+<BonadocsWidget client:only deploymentAddresses={deploymentAddresses} functionSignature="addNativeGas(bytes32 txHash, uint256 logIndex, address refundAddress) payable" />
+
 
 ```solidity
 function addNativeGas(
@@ -38,6 +63,8 @@ In Solidity, `addGas()` takes the following parameters:
 - `gasToken` — The ERC-20 token address used to add gas
 - `gasFeeAmount` — The amount of tokens to add as gas
 - `refundAddress` — The address where refunds, if any, should be sent
+
+<BonadocsWidget client:only deploymentAddresses={deploymentAddresses} functionSignature="addGas(bytes32 txHash, uint256 logIndex, address gasToken, uint256 gasFeeAmount, address refundAddress)" />
 
 ```solidity
 function addGas(


### PR DESCRIPTION
## Intro
As per our previous conversation @StephenFluin, this PR is to supercharge Axelar's documentation by adding interactive widgets that make it possible to interact with the Gas Service contracts directly inside the documentation. This results in better developer experience (DX) leading to an increase in protocol and app integrations for Axelar.

Demo: https://www.loom.com/share/b51581e50d67447db62bfd2c664336f2?sid=f8b29f6b-7cf9-4b9c-a7c5-f4425d8ff8b9

P.S: The widgets are self-sufficient and do not involve an IPFS call.