### PR TITLE
Update Flags for Scroll in order to support finalization

### DIFF
--- a/src/pages/validator/external-chains/scroll.mdx
+++ b/src/pages/validator/external-chains/scroll.mdx
@@ -80,7 +80,7 @@ Note: The following settings will allow your node to be accessed publicly from a
         --gcmode archive --cache.noprefetch \
         --http --http.vhosts "*" --http.addr "0.0.0.0" --http.port 8545 --http.api "eth,net,web3,debug,scroll" \
         --l1.endpoint "$L1_ENDPOINT" --l1.confirmations "finalized" \
-        --ws --ws.origins '*' --ws.addr 0.0.0.0
+        --ws --ws.origins '*' --ws.addr 0.0.0.0 --rollup.verify
 
         Restart=always
         RestartSec=3
@@ -108,7 +108,7 @@ Note: The following settings will allow your node to be accessed publicly from a
         --gcmode archive --cache.noprefetch \
         --http --http.vhosts "*" --http.addr "0.0.0.0" --http.port 8545 --http.api "eth,net,web3,debug,scroll" \
         --l1.endpoint "$L1_ENDPOINT" --l1.confirmations "finalized" \
-        --ws --ws.origins '*' --ws.addr 0.0.0.0
+        --ws --ws.origins '*' --ws.addr 0.0.0.0 --rollup.verify
 
         Restart=always
         RestartSec=3


### PR DESCRIPTION
As of [scroll v5.1.10](https://github.com/scroll-tech/go-ethereum/releases/tag/scroll-v5.1.10) the Scroll network RPCs support the `finalized` tag. 

However, in order for this tag to work correctly, node operators must pass an additional `--rollup.verify` flag to their node configs (See "Rollup Verification" in [release](https://github.com/scroll-tech/go-ethereum/releases/tag/scroll-v5.1.10). This flag should apply for both testnet and mainnet. 
