### PR TITLE
fix: broken code formatting in "gmp-example" page

### DIFF
--- a/src/pages/dev/amplifier/gmp-example.mdx
+++ b/src/pages/dev/amplifier/gmp-example.mdx
@@ -40,7 +40,7 @@ db0767","payload_hash":"64b8427717b2ce8573a0c37e03e30ec683c2fe57dcee4d426d22cf43
 
 Call `construct_proof()` at the multisig-prover corresponding to the destination chain:
 
-```
+```bash
 axelard tx wasm execute axelar1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv062tl '{"construct_proof":{"message_ids":[{"chain":"ethereum-sepolia","id":"0xeafbc1283699c49ba4f79ec43
 d8749fd82ca4ee14c236787dd25a2f7d4932daa:60"}]}}' --from validator --gas auto --gas-adjustment 1.5
 ```


### PR DESCRIPTION
the fenced code block for the `construct_proof()` example call is missing the 'bash' identifier

the code block is not rendered the same as other examples on the page and the contained code is truncated on the page

adds 'bash' identifier to fix formatting