### PR TITLE
fix: update config file example on verifier onboarding page

### DIFF
--- a/src/pages/validator/amplifier/verifier-onboarding.mdx
+++ b/src/pages/validator/amplifier/verifier-onboarding.mdx
@@ -46,44 +46,53 @@ These instructions require you to [install and use Docker](https://docs.docker.c
 
 1. Create an ampd configuration file at `~/.ampd/config.toml` (or choose a different location and refer to your chosen location later in ampd commands such as `ampd -config /home/me/devnet-verifiers.toml`). This configuration file tells `ampd` how to connect to your local `tofnd`, how to talk to the devnet and the Amplifier smart contracts, and includes a default configuration for verifying transactions on the Avalanche testnet.
 
-    The following is an example `config.toml` file for the verifier devnet:
+The following is the `config.toml` file format, with explanations for each entry:
 
-    ```bash
-    tm_jsonrpc="http://devnet-verifiers.axelar.dev:26657"
-    tm_grpc="tcp://devnet-verifiers.axelar.dev:9090"
-    event_buffer_cap=1000
+```bash
+tm_jsonrpc=[JSON-RPC URL of Axelar node]
+tm_grpc=[gRPC URL of Axelar node]
+event_buffer_cap=[max blockchain events to queue. Will error if set too low]
+health_check_bind_addr=[the /status endpoint bind address i.e "0.0.0.0:3000"]
 
-    [service_registry]
-    cosmwasm_contract="axelar1hrpna9v7vs3stzyd4z3xf00676kf78zpe2u5ksvljswn2vnjp3ystlgl4x"
+[service_registry]
+cosmwasm_contract=[address of service registry]
 
-    [broadcast]
-    batch_gas_limit="1000000"
-    broadcast_interval="1s"
-    chain_id="devnet-verifiers"
-    gas_adjustment="2"
-    gas_price="0.00005uverifiers"
-    queue_cap="1000"
-    tx_fetch_interval="600ms"
-    tx_fetch_max_retries="10"
+[broadcast]
+batch_gas_limit=[max gas for a transaction. Transactions can contain multiple votes and signatures]
+broadcast_interval=[how often to broadcast transactions]
+chain_id=[chain id of Axelar network to connect to]
+gas_adjustment=[gas adjustment to use when broadcasting]
+gas_price=[gas price with denom, i.e. "0.007uaxl"]
+queue_cap=[max messages to queue when broadcasting]
+tx_fetch_interval=[how often to query for transaction inclusion in a block]
+tx_fetch_max_retries=[how many times to query for transaction inclusion in a block before failing]
 
-    [tofnd_config]
-    batch_gas_limit="10000000"
-    key_uid="axelar"
-    party_uid="ampd"
-    url="http://127.0.0.1:50051"
+[tofnd_config]
+key_uid=[uid of key used for signing transactions]
+party_uid=[metadata, should just be set to ampd]
+url=[url of tofnd]
 
-    [[handlers]]
-    cosmwasm_contract="axelar1ufs3tlq4umljk0qfe8k5ya0x6hpavn897u2cnf9k0en9jr7qarqqa9263g"
-    type="MultisigSigner"
+# multisig handler. This handler is used for all supported chains.
+[[handlers]]
+cosmwasm_contract=[address of multisig contract]
+type="MultisigSigner"
 
-    [[handlers]]
-    chain_name="avalanche"
-    chain_rpc_url="https://avalanche-fuji-c-chain-rpc.publicnode.com"
-    cosmwasm_contract="axelar1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4687qd"
-    type="EvmMsgVerifier"
-    ```
+# message verifier handler. One per supported chain
+[[handlers]]
+chain_name=[chain name. Not necessary in the Sui case]
+chain_rpc_url=[URL of JSON-RPC endpoint for external chain]
+cosmwasm_contract=[verifier contract address]
+type=[handler type. Could be EvmMsgVerifier | SuiMsgVerifier]
 
-See the [`ampd` README](https://github.com/axelarnetwork/axelar-amplifier/blob/main/ampd/README.md) on GitHub for instructions on formatting a `config` file for your own projects.
+# handler to verify verifier set rotations. One per supported chain
+[[handlers]]
+chain_name=[chain name. Not necessary in the Sui case]
+chain_rpc_url=[URL of JSON-RPC endpoint for external chain]
+cosmwasm_contract=[verifier contract address]
+type=[handler type. Could be EvmVerifierSetVerifier | SuiVerifierSetVerifier]
+```
+
+See the [`ampd` README](https://github.com/axelarnetwork/axelar-amplifier/blob/main/ampd/README.md) on GitHub for an example verifier devnet config file.
 
 ## Fund your wallet
 


### PR DESCRIPTION
We added external verifiers to the Amplifier devnet assuming they would become verifiers for their own chain, but did not instruct them specifically to not register for other chains. They may have done this inadvertently if they copied any of the entries in the template `config.toml` on the verifier onboarding page. Since deauthorizing a verifier will deauthorize that address for every connection, we will deauthorize the verifier addresses that were added and have our own verifiers become verifiers for those chains. We will re-add them after communicating to partners that they should only declare support for their own chain. [[source](https://interoplabs.slack.com/archives/C04K4J95GKC/p1716929066865519?thread_ts=1716928383.877169&cid=C04K4J95GKC)]

WRT docs, change the example `config.toml` file to the generic format in the [`ampd` README](https://github.com/axelarnetwork/axelar-amplifier/blob/main/ampd/README.md) on GitHub to prevent this from happening again.

Preview: https://axelar-docs-git-marty-ampd-config-axelar-network.vercel.app/validator/amplifier/verifier-onboarding