### PR TITLE
fix: validator unjailing testnet chain id

### DIFF
--- a/src/pages/validator/troubleshoot/unjail.mdx
+++ b/src/pages/validator/troubleshoot/unjail.mdx
@@ -20,5 +20,5 @@ axelard tx slashing unjail --from validator
 ## Binaries
 
 ```bash
-~/.axelar_testnet/bin/axelard tx slashing unjail --from validator --home ~/.axelar_testnet/.core --chain-id axelar-testnet-toronto
+~/.axelar_testnet/bin/axelard tx slashing unjail --from validator --home ~/.axelar_testnet/.core --chain-id axelar-testnet-lisbon-3
 ```


### PR DESCRIPTION
Replaces #936 