### PR TITLE
fix: update new multisig prover instantiation fields

### DIFF
--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -311,6 +311,10 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
     ```
     Now instantiate the contract.
 
+    <Callout>
+    The `domain_separator` is the hash of the chain name, router address, and Axelar chain ID coded in command line JSON as an array of bytes.
+    </Callout>
+
     ```bash
     axelard tx wasm instantiate $PROVER_CODE_ID \
         '{
@@ -327,7 +331,7 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
             "verifier_set_diff_threshold": 1,
             "encoder": "abi",
             "key_type": "ecdsa"
-            "domain_separator":[hash of (chain-name + router-address + axelar-chain-id)]
+            "domain_separator":[hash(chain_name, router_address, MY_CHAIN_ID)]
         }' \
         --keyring-backend test \
         --from wallet \

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -330,7 +330,7 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
             "chain_name":"test",
             "verifier_set_diff_threshold": 1,
             "encoder": "abi",
-            "key_type": "ecdsa"
+            "key_type": "ecdsa",
             "domain_separator":[hash(chain_name, router_address, MY_CHAIN_ID)]
         }' \
         --keyring-backend test \

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -327,7 +327,7 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
             "verifier_set_diff_threshold": 1,
             "encoder": "abi",
             "key_type": "ecdsa"
-            "domain_separator": ${randomHash()}
+            "domain_separator":[hash of (chain-name + router-address + axelar-chain-id)]
         }' \
         --keyring-backend test \
         --from wallet \

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -321,13 +321,13 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
             "coordinator_address":"axelar1m2498n4h2tskcsmssjnzswl5e6eflmqnh487ds47yxyu6y5h4zuqr9zk4g",
             "service_registry_address":"axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz",
             "voting_verifier_address": "'"$MY_VERIFIER_ADDRESS"'",
-            "destination_chain_id": "'"$MY_CHAIN_ID"'",
             "signing_threshold": ["1","1"],
             "service_name": "validators",
             "chain_name":"test",
-            "worker_set_diff_threshold": 1,
+            "verifier_set_diff_threshold": 1,
             "encoder": "abi",
             "key_type": "ecdsa"
+            "domain_separator": ${randomHash()}
         }' \
         --keyring-backend test \
         --from wallet \


### PR DESCRIPTION
Update instantiation instructions for the multisig prover on chain integration doc to reflect [current fields on GitHub](https://github.com/axelarnetwork/axelar-amplifier/blob/ampd-v0.4.0/contracts/multisig-prover/src/msg.rs)

Preview: https://axelar-docs-git-marty-multisig-prover-ins-dd0df7-axelar-network.vercel.app/dev/amplifier/chain-integration/integrate-a-chain