### PR TITLE
feat: verifier governance proposal doc

### DIFF
--- a/src/layouts/navigation.ts
+++ b/src/layouts/navigation.ts
@@ -416,6 +416,10 @@ export const getNavigation = (section) => {
               title: "Become a verifier",
               href: "/validator/amplifier/verifier-onboarding",
             },
+            {
+              title: "Governance proposals",
+              href: "/validator/amplifier/verifier-governance-proposal",
+            },
           ],
         },
       ],

--- a/src/pages/validator/amplifier/verifier-governance-proposal.mdx
+++ b/src/pages/validator/amplifier/verifier-governance-proposal.mdx
@@ -1,0 +1,166 @@
+# Create and submit a governance proposal for your verifier
+
+Most important operations on Amplifier must be authorized via on-chain governance proposal, including registering and upgrading contracts, bonding and unbonding verifiers, and configuring rewards parameters such as rate and epoch.
+
+The following instructions will guide you through creating, submitting, and getting votes for four types of governance proposals:
+
+1. [A proposal to change upload permission to governance address only](/validator/amplifier/verifier-governance-proposal#proposal-to-change-upload-permission-to-governance-address-only)
+1. [A proposal to create a new contract](/validator/amplifier/verifier-governance-proposal#proposal-to-create-a-new-contract)
+1. [A proposal to instantiate a new contract](/validator/amplifier/verifier-governance-proposal#proposal-to-instantiate-a-new-contract)
+
+## Prerequisites
+
+To create and submit a governance proposal, make sure you have:
+
+- Access to the Amplifier testnet
+- An account with enough funds to create a proposal
+- An updated version of `axelard` with `wasm` enabled. If you don’t have this, run `make WASM=true build`.
+
+## Set up your environment
+
+1. Set the testnet parameters to environment variables:
+
+    ```bash
+    TESTNET=...
+    RPC=http://...
+    GOVERNANCE=axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj
+    ```
+
+1. Run the optimizer to get the contract’s bytecode. This should be done via a [Docker container](https://www.docker.com/) to ensure that the bytecode is built with the proper environment. The following command builds the contract and saves it to the `artifacts` folder:
+
+    ```bash
+    docker run --rm -v "$(pwd)":/code --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry cosmwasm/workspace-optimizer-arm64:0.12.13
+    ```
+
+## Proposal to change upload permission to governance address only
+
+1. Create a proposal in the JSON file format. For example:
+
+    ```bash
+    {
+    "title": "set upload access address to axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+    "description": "set wasm code upload access to axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+    "changes": [
+        {
+        "subspace": "wasm",
+        "key": "uploadAccess",
+        "value": {
+            "permission": "AnyOfAddresses",
+            "address": "",
+            "addresses": ["axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj"]
+        }
+        }
+    ],
+    "deposit": "200000000uaxl"
+    }
+    ```
+
+1. Save the JSON proposal to a file, such as `gov-proposal.json`.
+
+1. In your terminal, create a `GOV_PROPOSAL` variable and set its value to the path of your JSON file:
+
+    ```bash
+    GOV_PROPOSAL=/Users/you/Projects/Axelar/gov-proposal.json
+    ```
+
+1. Submit the proposal:
+
+    ```bash
+    axelard tx gov submit-proposal param-change $GOV_PROPOSAL --from test --output json --gas auto --gas-adjustment 2 --gas-prices=0.00005$DENOM --node $RPC --chain-id $TESTNET
+    ```
+
+1. Set the PROPOSAL_ID based on the submission output:
+
+    ```bash
+    PROPOSAL_ID=3
+    ```
+
+1. Ask other verifiers on the [Axelar Discord](https://discord.com/invite/axelar), Telegram groups, and [Forum](https://community.axelar.network/) to vote on your proposal. You can also use other accounts to vote for your own proposal.
+
+## Proposal to create a new contract
+
+1. Create your proposal in a JSON file format.
+
+1. Set the contract variables. You can get the hash from the optimizer output:
+
+    ```bash
+    CONTRACT_WASM=artifacts/service_registry-aarch64.wasm
+    CONTRACT_SOURCE=https://github.com/axelarnetwork/axelar-amplifier/tree/main/contracts/service-registry #fix this
+    CONTRACT_CODE_HASH=20814e7f6a11bb7be119babbd233c3a647a2c8b5d9376eb810729152288d225c
+    ```
+
+1. Submit the proposal:
+
+    ```bash
+    axelard tx gov submit-proposal wasm-store $CONTRACT_WASM --code-source-url $CONTRACT_SOURCE --builder "cosmwasm/workspace-optimizer-arm64:0.12.13" --code-hash $CONTRACT_CODE_HASH --instantiate-anyof-addresses $GOVERNANCE --title "Upload service registry" --description "Upload service registry" --run-as $(axelard keys show -a test) --deposit "200000000uedwin" --from test --output json --gas auto --gas-adjustment 2 --gas-prices=0.00005$DENOM --node $RPC --chain-id $TESTNET
+    ```
+
+1. Set the `PROPOSAL_ID` variable based on submission output:
+
+    ```bash
+    PROPOSAL_ID=8
+    ```
+
+1. Ask other verifiers on the [Axelar Discord](https://discord.com/invite/axelar), Telegram groups, and [Forum](https://community.axelar.network/) to vote on your proposal. You can also use other accounts to vote for your own proposal.
+
+1. Query the contracts for their  CODE_IDs to get their newest addresses. It might take a while for the proposal to be executed:
+
+    ```bash
+    axelar-service-registry % axelard q wasm list-code --node $RPC --chain-id $TESTNET
+    ```
+
+    ```bash
+    - code_id: "4"
+    creator: axelar1a8ldskqrlkc0pushavypu359s5dvxcs3xgzu69
+    data_hash: 20814E7F6A11BB7BE119BABBD233C3A647A2C8B5D9376EB810729152288D225C
+    instantiate_permission:
+        address: ""
+        addresses:
+        - axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj
+        permission: AnyOfAddresses
+    ```
+
+    ```bash
+    CODE_ID=4
+    ```
+
+1. Try to instantiate from non-governance address, which should throw a [`caller is not authorized`](https://github.com/axelarnetwork/axelar-amplifier/blob/6fd3612716fc6cf3b421ebe53939a71341731047/packages/router-api/src/error.rs#L18) [error](https://github.com/axelarnetwork/axelar-amplifier/blob/6fd3612716fc6cf3b421ebe53939a71341731047/contracts/coordinator/src/execute.rs#L12):
+
+    ```bash
+    axelard tx wasm instantiate $CODE_ID '{"governance_account":"'$GOVERNANCE'"}' --from test --gas auto --gas-adjustment 2 --gas-prices=0.00005$DENOM --node $RPC --chain-id $TESTNET --label service_registry --no-admin
+    ```
+
+## Proposal to instantiate a new contract
+
+1. Create your proposal in a JSON file format.
+
+1. Submit the proposal to instantiate your contract:
+
+    ```bash
+    axelard tx gov submit-proposal instantiate-contract $CODE_ID '{"governance_account":"'$GOVERNANCE'"}' --label service_registry --no-admin --title "Instantiate service registry" --description "Instantiate service registry" --run-as $(axelard keys show -a test) --deposit "200000000uedwin" --from test --output json --gas auto --gas-adjustment 2 --gas-prices=0.00005$DENOM --node $RPC --chain-id $TESTNET
+    ```
+
+1. Set the `PROPOSAL_ID` variable based on submission output:
+
+    ```bash
+    PROPOSAL_ID=12
+    ```
+
+1. Ask other verifiers on the [Axelar Discord](https://discord.com/invite/axelar), Telegram groups, and [Forum](https://community.axelar.network/) to vote on your proposal. You can also use other accounts to vote for your own proposal.
+
+1. Query the contracts for their  `CODE_ID`s to get their newest addresses. It might take a while for the proposal to be executed:
+
+    ```bash
+    axelard q wasm list-contract-by-code $CODE_ID --node $RPC --chain-id $TESTNET
+    ```
+
+    ```bash
+    contracts:
+    - axelar1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqhk6q2n
+    - axelar1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqt7a82d
+    - axelar1xt4ahzz2x8hpkc0tk6ekte9x6crw4w6u0r67cyt3kz9syh24pd7scrmm2x
+    - axelar1kj8q8g2pmhnagmfepp9jh9g2mda7gzd0m5zdq0s08ulvac8ck4dqz8wvmz
+    pagination:
+    next_key: null
+    total: "0"
+    ```


### PR DESCRIPTION
New verifier doc explaining how to change upload permissions, create a new contract, and instantiate a new contract on the testnet.

Preview: https://axelar-docs-git-marty-verifier-governance-15b40f-axelar-network.vercel.app/validator/amplifier/verifier-governance-proposal

## Sources

- [[Docs] CosmWasm Governance Proposals](https://docs.axelar.dev/learn/cosmwasm-governance)
- [[Notion] Amplifier - Upload/instantiate through governance proposal](https://www.notion.so/bright-ambert-2bd/Amplifier-Upload-instantiate-through-governance-proposal-e8e1a4df87084982b80c296b92a126de)