### PR TITLE
fix: various verifier onboarding doc issues

### DIFF
--- a/src/pages/validator/amplifier/verifier-onboarding.mdx
+++ b/src/pages/validator/amplifier/verifier-onboarding.mdx
@@ -57,18 +57,18 @@ Install `ampd` from source by cloning and building the [`axelar-amplifier` repos
 </tab-item>
 
 <tab-item title="Binary">
-Download the [`ampd` binary](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v0.4.0) depending on the type of machine you have:
-    - Linux: [`ampd-linux-amd64-v0.4.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.4.0/ampd-linux-amd64-v0.4.0)
-    - Apple Silicon Mac: [`ampd-darwin-arm64-v0.4.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.4.0/ampd-darwin-arm64-v0.4.0)
-    - Intel Mac: [`ampd-darwin-amd64-v0.4.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.4.0/ampd-darwin-amd64-v0.4.0)
+Download the [`ampd` binary](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v0.5.0) depending on the type of machine you have:
+    - Linux: [`ampd-linux-amd64-v0.5.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.5.0/ampd-linux-amd64-v0.5.0)
+    - Apple Silicon Mac: [`ampd-darwin-arm64-v0.5.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.5.0/ampd-darwin-arm64-v0.5.0)
+    - Intel Mac: [`ampd-darwin-amd64-v0.5.0`](https://github.com/axelarnetwork/axelar-amplifier/releases/download/ampd-v0.5.0/ampd-darwin-amd64-v0.5.0)
 </tab-item>
 
 <tab-item title="Docker">
-From [Docker](https://hub.docker.com/r/axelarnet/axelar-ampd), pull and run the `0.4.0` version of `ampd`:
+From [Docker](https://hub.docker.com/r/axelarnet/axelar-ampd), pull and run the `0.5.0` version of `ampd`:
 
 ```bash
-docker pull axelarnet/axelar-ampd:v0.4.0
-docker run axelarnet/axelar-ampd:v0.4.0 verifier-address
+docker pull axelarnet/axelar-ampd:v0.5.0
+docker run axelarnet/axelar-ampd:v0.5.0 verifier-address
 ```
 </tab-item>
 
@@ -80,33 +80,35 @@ This will allow you to begin commands with `ampd`. If you set up `ampd` through 
 
 <tabs>
 
-<tab-item title="Symlink">
+<tab-item title="Symbolic link">
+<Callout>
+Replace `ampd-darwin-arm64-v0.5.0` with the [`ampd` binary you downloaded](/validator/amplifier/verifier-onboarding#set-up-ampd).
+</Callout>
 1. Add a symbolic link named `ampd` to the `ampd` binary on your machine:
 
     ```bash
-    sudo ln -s <BINARY PATH> /usr/local/bin/ampd
+    sudo ln -s ~/Downloads/ampd-darwin-arm64-v0.5.0 /usr/local/bin/ampd
     ```
 1. Make the binary executable:
 
     ```bash
-    chmod a+x Downloads/ampd-darwin-arm64-v0.4.0
+    chmod a+x ~/Downloads/ampd-darwin-arm64-v0.5.0
     ```
 
 1. Restart your terminal.
 
-1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.5.0`.
 </tab-item>
 
 <tab-item title="<code>bash</code> alias">
-1. Open the `.bashrc` file on your machine.
+<Callout>
+Replace `ampd-darwin-arm64-v0.5.0` with the [`ampd` binary you downloaded](/validator/amplifier/verifier-onboarding#set-up-ampd).
+</Callout>
+
+1. Add an alias to `ampd` at the end of the `.bashrc` file on your machine:
 
     ```bash
-    open ~/.bashrc
-    ```
-1. Add an alias to `ampd` at the end of the file:
-
-    ```bash
-    alias ampd=<BINARY PATH>
+    echo "ampd=~/Downloads/ampd-darwin-arm64-v0.5.0" >> ~/.bashrc
     ```
 
 1. Save and close the file.
@@ -119,19 +121,17 @@ This will allow you to begin commands with `ampd`. If you set up `ampd` through 
 
 1. Restart your terminal.
 
-1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.5.0`.
 </tab-item>
 
 <tab-item title="<code>zsh</code> alias">
-1. Open the `.zshrc` file on your machine.
+<Callout>
+Replace `ampd-darwin-arm64-v0.5.0` with the [`ampd` binary you downloaded](/validator/amplifier/verifier-onboarding#set-up-ampd).
+</Callout>
+1. Add an alias to `ampd` at the end of the `.zshrc` file on your machine:
 
     ```bash
-    open ~/.zshrc
-    ```
-1. Add an alias to `ampd` at the end of the file:
-
-    ```bash
-    alias ampd=<BINARY PATH>
+    echo "ampd=~/Downloads/ampd-darwin-arm64-v0.5.0" >> ~/.zshrc
     ```
 
 1. Save and close the file.
@@ -144,7 +144,7 @@ This will allow you to begin commands with `ampd`. If you set up `ampd` through 
 
 1. Restart your terminal.
 
-1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.5.0`.
 </tab-item>
 
 </tabs>
@@ -215,7 +215,7 @@ Prior to running the `ampd` daemon, you will need to set up your wallet with dev
     ```
 
     <Callout>
-    If you get a security warning while trying to run `ampd` on an Apple Silicon Mac, you can disable the [gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web) for a single binary with `sudo xattr -d com.apple.quarantine Downloads/ampd-darwin-arm64-v0.4.0` or disable gatekeeper globally with `sudo spctl --master-disable`.
+    If you get a security warning while trying to run `ampd` on an Apple Silicon Mac, you can disable the [gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web) for a single binary with `sudo xattr -d com.apple.quarantine ~/Downloads/ampd-darwin-arm64-v0.5.0` or disable gatekeeper globally with `sudo spctl --master-disable`.
     </Callout>
 
 1. Fund your verifier address.

--- a/src/pages/validator/amplifier/verifier-onboarding.mdx
+++ b/src/pages/validator/amplifier/verifier-onboarding.mdx
@@ -78,33 +78,76 @@ docker run axelarnet/axelar-ampd:v0.4.0 verifier-address
 
 This will allow you to begin commands with `ampd`. If you set up `ampd` through source or Docker, make sure to build a binary first.
 
+<tabs>
+
+<tab-item title="Symlink">
 1. Add a symbolic link named `ampd` to the `ampd` binary on your machine:
 
     ```bash
-    sudo ln -s <BINARY NAME> /usr/local/bin/ampd
+    sudo ln -s <BINARY PATH> /usr/local/bin/ampd
+    ```
+1. Make the binary executable:
+
+    ```bash
+    chmod a+x Downloads/ampd-darwin-arm64-v0.4.0
     ```
 
-1. Run the following to add an alias called `ampd` to the binary:
+1. Restart your terminal.
+
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+</tab-item>
+
+<tab-item title="<code>bash</code> alias">
+1. Open the `.bashrc` file on your machine.
+
+    ```bash
+    open ~/.bashrc
+    ```
+1. Add an alias to `ampd` at the end of the file:
 
     ```bash
     alias ampd=<BINARY PATH>
     ```
 
-1. Make the binary executable:
+1. Save and close the file.
+
+1. Reload the file to apply all changes:
 
     ```bash
-    chmod a+x ./ampd-darwin-arm64-v0.4.0
+    source ~/.bashrc
     ```
 
 1. Restart your terminal.
 
-All instructions in this tutorial will assume you have a binary in your `PATH` named `ampd`. If you don't want to add `ampd` to your `PATH`, you can refer to the binary directly in every command in this tutorial, replacing `ampd` with the `ampd` version that corresponds with your machine.
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+</tab-item>
 
-For example, to determine the verifier address without the `ampd` alias on an Apple Silicon Mac, you would run:
+<tab-item title="<code>zsh</code> alias">
+1. Open the `.zshrc` file on your machine.
 
-```bash
-~/ampd-darwin-arm64-v0.4.0 verifier-address
-```
+    ```bash
+    open ~/.zshrc
+    ```
+1. Add an alias to `ampd` at the end of the file:
+
+    ```bash
+    alias ampd=<BINARY PATH>
+    ```
+
+1. Save and close the file.
+
+1. Reload the file to apply all changes:
+
+    ```bash
+    source ~/.zshrc
+    ```
+
+1. Restart your terminal.
+
+1. Run `ampd --version` to make sure that the right version of `ampd` was installed on your machine. It should be `ampd 0.4.0`.
+</tab-item>
+
+</tabs>
 
 ## Configure the verifier
 
@@ -148,15 +191,14 @@ The following is an example `config.toml` file for the verifier devnet:
     cosmwasm_contract="axelar1elaymnd2epmfr498h2x9p2nezc4eklv95uv92u9csfs8wl75w7yqdc0h67"
     type="EvmMsgVerifier"
 
+    [[handlers]]
+    chain_name="ethereum-sepolia"
+    chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
+    cosmwasm_contract="axelar1sxujcvele5eqtx0xc4wuy6jr0m28y0yt8spn7efc3527vc2j2xrqk6wkay"
+    type="EvmMsgVerifier"
     ```
 
 See the [`ampd` README](https://github.com/axelarnetwork/axelar-amplifier/blob/main/ampd/README.md) on GitHub for instructions on formatting a `config` file for your own projects.
-
-You can choose a different location for `config.toml` and refer to your chosen location rather than to `~/.ampd` in `ampd` commands. For example, if you saved your the config file in `/home/me/`, you would run:
-
-```bash
-ampd -config /home/me/devnet-verifiers.toml
-```
 
 <Callout>
 If you get a transport error with an `ampd` command, make sure that you have `tofnd` running in the background.
@@ -173,7 +215,7 @@ Prior to running the `ampd` daemon, you will need to set up your wallet with dev
     ```
 
     <Callout>
-    If you get a security warning while trying to run `ampd` on an Apple Silicon Mac, you can disable the [gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web) for a single binary with `sudo xattr -d com.apple.quarantine ./ampd-darwin-arm64-v0.4.0` or disable gatekeeper globally with `sudo spctl --master-disable`.
+    If you get a security warning while trying to run `ampd` on an Apple Silicon Mac, you can disable the [gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web) for a single binary with `sudo xattr -d com.apple.quarantine Downloads/ampd-darwin-arm64-v0.4.0` or disable gatekeeper globally with `sudo spctl --master-disable`.
     </Callout>
 
 1. Fund your verifier address.


### PR DESCRIPTION
* Change numbered steps for alias / symlink into different tabbed sections: either symlink, `bash` permanent alias, or `zsh` permanent alias
* Change `BINARY NAME` to `BINARY PATH`
* Add instructions for running `ampd —version` to verify installed version
* Add `chain_name="ethereum-sepolia”` to sample `config.toml`
* Replace home directory with Downloads folder in commands referring to the `ampd` path
* Remove non-happy-path instructions

Preview: https://axelar-docs-git-marty-fix-verifier-onboarding-axelar-network.vercel.app/validator/amplifier/verifier-onboarding