### PR TITLE
fix: remove empty caution from verifier onboarding doc

### DIFF
--- a/src/pages/validator/amplifier/verifier-onboarding.mdx
+++ b/src/pages/validator/amplifier/verifier-onboarding.mdx
@@ -93,8 +93,6 @@ This will allow you to begin commands with `ampd`. If you set up `ampd` through 
 <tabs>
 
 <tab-item title="Symbolic link">
-<Callout>
-</Callout>
 1. Add a symbolic link named `ampd` in your binaries folder.:
 
     ```bash


### PR DESCRIPTION
Preview: https://axelar-docs-git-marty-remove-caution-axelar-network.vercel.app/validator/amplifier/verifier-onboarding