### PR TITLE
fix: GMP example contract addresses

### DIFF
--- a/src/pages/dev/amplifier/gmp-example.mdx
+++ b/src/pages/dev/amplifier/gmp-example.mdx
@@ -12,7 +12,7 @@ You will need:
 ## Helpful references
 
 - [Amplifier devnet contract addresses](https://github.com/axelarnetwork/axelar-contract-deployments/pull/187/files)
-- [`axelar-amplifier GitHub repository`](https://github.com/axelarnetwork/axelar-amplifier)
+- [`axelar-amplifier` GitHub repository](https://github.com/axelarnetwork/axelar-amplifier)
 
 ## Send a GMP call between two chains
 
@@ -25,24 +25,69 @@ Use `callContract()` to execute the contract call on Ethereum Sepolia, then loca
 Once the transaction is finalized on the source chain, call `verify_messages()` at the source chain’s `AxelarGateway`:
 
 ```bash
-axelard tx wasm execute axelar18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtsltrlkp '{"verify_messages":[{"cc_id":{"chain":"ethereum-sepolia","id":"0xeafbc1283699c49ba4f79ec43d8749f
-d82ca4ee14c236787dd25a2f7d4932daa-60"},"destination_chain":"avalanche","destination_address":"0x79a35Fd62DbAa820D3025B3400eBcE17Cdd6C587","source_address":"0xA4f10f76B86E01B98daF66A3d02a65e14
-adb0767","payload_hash":"64b8427717b2ce8573a0c37e03e30ec683c2fe57dcee4d426d22cf43c7692675"}]}' --from validator --gas auto --gas-adjustment 1.5
+axelard tx wasm execute axelar18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtsltrlkp \
+  '{
+      "verify_messages":
+        [
+          {
+            "cc_id":
+              {
+                "chain":"ethereum-sepolia",
+                "id":"0xeafbc1283699c49ba4f79ec43d8749fd82ca4ee14c236787dd25a2f7d4932daa-60"
+              },
+            "destination_chain":"avalanche",
+            "destination_address":"0xCa85f85C72df5f8428a440887CA7c449D94e0D0c",
+            "source_address":"0x6F4f1eb0546872c4BE7bCe4EaD35f24119A5DA77",
+            "payload_hash":"64b8427717b2ce8573a0c37e03e30ec683c2fe57dcee4d426d22cf43c7692675"
+          }
+        ]
+  }' \
+  --from validator \
+  --gas auto --gas-adjustment 1.5
 ```
 
 Wait for verification, which usually takes 1-3 blocks. Then call `route_messages()`:
 
 ```bash
-axelard tx wasm execute axelar18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtsltrlkp '{"route_messages":[{"cc_id":{"chain":"ethereum-sepolia","id":"0xeafbc1283699c49ba4f79ec43d8749fd
-82ca4ee14c236787dd25a2f7d4932daa-60"},"destination_chain":"avalanche","destination_address":"0x79a35Fd62DbAa820D3025B3400eBcE17Cdd6C587","source_address":"0xA4f10f76B86E01B98daF66A3d02a65e14a
-db0767","payload_hash":"64b8427717b2ce8573a0c37e03e30ec683c2fe57dcee4d426d22cf43c7692675"}]}' --from validator --gas auto --gas-adjustment 1.5
+axelard tx wasm execute axelar18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtsltrlkp \
+  '{
+    "route_messages":
+      [
+          {
+            "cc_id":
+              {
+                "chain":"ethereum-sepolia",
+                "id":"0xeafbc1283699c49ba4f79ec43d8749fd82ca4ee14c236787dd25a2f7d4932daa-60"
+              },
+            "destination_chain":"avalanche",
+            "destination_address":"0xCa85f85C72df5f8428a440887CA7c449D94e0D0c",
+            "source_address":"0x6F4f1eb0546872c4BE7bCe4EaD35f24119A5DA77",
+            "payload_hash":"64b8427717b2ce8573a0c37e03e30ec683c2fe57dcee4d426d22cf43c7692675"
+          }
+      ]
+  }' \
+  --from validator \
+  --gas auto --gas-adjustment 1.5
 ```
 
 Call `construct_proof()` at the multisig-prover corresponding to the destination chain:
 
 ```bash
-axelard tx wasm execute axelar1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv062tl '{"construct_proof":{"message_ids":[{"chain":"ethereum-sepolia","id":"0xeafbc1283699c49ba4f79ec43
-d8749fd82ca4ee14c236787dd25a2f7d4932daa-60"}]}}' --from validator --gas auto --gas-adjustment 1.5
+axelard tx wasm execute axelar1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv062tl \
+  '{
+    "construct_proof":
+      {
+        "message_ids":
+          [
+            {
+              "chain":"ethereum-sepolia",
+              "id":"0xeafbc1283699c49ba4f79ec43d8749fd82a4ee14c236787dd25a2f7d4932daa-60"
+            }
+          ]
+      }
+  }' \
+  --from validator \
+  --gas auto --gas-adjustment 1.5
 ```
 
 Note the `multisig_session_id` in the output:
@@ -56,7 +101,13 @@ Note the `multisig_session_id` in the output:
 Wait for signing to complete, which usually takes 1-3 blocks. Then call `get_proof()`:
 
 ```bash
-axelard q wasm contract-state smart axelar1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv062tl '{"get_proof":{"multisig_session_id":"1"}}'
+axelard q wasm contract-state smart axelar1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv062tl \
+  '{
+    "get_proof":
+      {
+        "multisig_session_id":"1"
+      }
+  }'
 ```
 
 The output should look something like this:
@@ -91,5 +142,5 @@ The execute data can be relayed to the destination chain’s `AxelarGateway` in 
 Fill in the appropriate values and execute the contract. The `command_id` can be found in the response to the `get_proof` query:
 
 ```js
-> await contract.execute(ethers.utils.arrayify(command_id),source_chain, source_address, ethers.utils.arrayify(payload)).then((tx) => tx.wait()
+> await contract.execute(ethers.utils.arrayify(command_id),source_chain, source_address, ethers.utils.arrayify(payload)).then((tx) => tx.wait())
 ```


### PR DESCRIPTION
- Fix `source_address` and `destination_address` to match new [`devnet-amplifier` contract deployments](https://github.com/axelarnetwork/axelar-contract-deployments/pull/187/files)
- Update formatting for `wasm` commands
- Fix formatting (links and missing parenthesis)

Preview: https://axelar-docs-git-marty-gmp-example-contrac-dedd65-axelar-network.vercel.app/dev/amplifier/gmp-example