### PR TITLE
fix: update chain integration tutorial

### DIFF
--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -82,7 +82,7 @@ To build the `axelard` binary from source:
 
 ## Onboard a chain with Amplifier
 
-Once you are running `ampd` and `tofnd`, you can onboard a chain with the Amplifier by instantiating the `gateway`, `voting verifier`, and `multisig prover` contracts.
+You can onboard a chain with the Amplifier by instantiating the `gateway`, `voting verifier`, and `multisig prover` contracts.
 
 You can either use the existing deployed contracts and on the devnet via their `code_id`s (CosmWasm identifiers for stored contracts that can be instantiated), or build and store these contracts from the `axelar-examples` repo. **You will need to instantiate the contracts no matter which option you choose.**
 
@@ -185,7 +185,7 @@ Use the existing deployments for all three contracts, making note of the existin
         --node http://devnet-amplifier.axelar.dev:26657
     ```
 
-    Remember to save your `code_id`s.
+    Remember to save your contract's `code_id`.
 
 
 1. Deploy the multisig prover:
@@ -199,7 +199,7 @@ Use the existing deployments for all three contracts, making note of the existin
         --node http://devnet-amplifier.axelar.dev:26657
     ```
 
-    Remember to save your `code_id`s.
+    Remember to save your contract's `code_id`.
 </tab-item>
 
 <tab-item title="Use custom implementation">
@@ -210,9 +210,10 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
 
 ## Instantiate the contracts
         
-1. Instantiate the voting verifier:
+### Instantiate the voting verifier
 
-    Set your parameters.
+1. Instantiate the voting verifier contract on the command line.
+
     ```bash
     export VERIFIER_CODE_ID=500 # Set your Code ID
     export MY_WALLET_ADDRESS="axelar14r0xzwz8hmkshau39dyja5kx503dx6zu52623h"
@@ -245,7 +246,7 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
     {/* message_id_format is coming soon should be HexTxHashAndEventIndex (0) or
    Base58TxDigestAndEventIndex (1), */}
     
-    Search the output of this command and note the `_contract_address`. It will be in the in `logs.events` property. You'll need to do this for each instantiation to use in future steps.
+1. Search the output of this command and note the `_contract_address`. It will be in the in `logs.events` property. You'll need to do this for each instantiation to use in future steps.
 
     ```bash
     {
@@ -283,14 +284,15 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
     }
     ```
     
-1. Instantiate the gateway:
+### Instantiate the gateway
 
-    Set your parameters, including the verifier address from the previous step.
+1. Instantiate the gateway contract on the command line with the verifier address from the previous step.
+
     ```bash
     export GATEWAY_CODE_ID=493 # Set your Code ID
     export MY_VERIFIER_ADDRESS="axelar1x3960tw9cml6xsqtvzt4gmw3scauaxdd83rhs9dmlpjfjf9z9s7qjx8g0j"
     ```
-    Now instantiate the contract.
+1. Instantiate the contract.
     
     ```bash
     axelard tx wasm instantiate $GATEWAY_CODE_ID \
@@ -307,20 +309,21 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
         --admin $MY_WALLET_ADDRESS
     ```
 
-    Search the output of this command and note the `_contract_address`. 
+1. Search the output of this command and note the `_contract_address`. 
 
-1. Instantiate the multisig prover:
+## Instantiate the multisig prover
 
-    Set your parameters, including the gateway address from the previous step.
+1. Instantiate the multisig prover contract on the command line with the gateway address from the previous step.
+
     ```bash
     export PROVER_CODE_ID=495 # Set your Code ID
     export MY_GATEWAY_ADDRESS="axelar1ufs3tlq4umljk0qfe8k5ya0x6hpavn897u2cnf9k0en9jr7qarqqa9263g"
     export MY_CHAIN_ID=43113
     ```
-    Now instantiate the contract.
+1. Instantiate the contract.
 
     <Callout>
-    The `domain_separator` is a 32-length byte array derived from the hash of the chain name, router address, and Axelar chain ID.
+    The `domain_separator` is a String in hex format without `0x`, such as "598ba04d225cec385d1ce3cf3c9a076af803aa5c614bc0e0d176f04ac8d28f55". It is derived from the hash of the chain name, router address, and Axelar chain ID.
     </Callout>
 
     ```bash
@@ -350,10 +353,11 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
         --admin $MY_WALLET_ADDRESS
     ```
 
-   Search the output of this command and note the `_contract_address`.
+1. Search the output of this command and note the `_contract_address`.
 
+## Whitelist your contract addresses
 
-1. Send the chain’s gateway and multisig prover contract addresses to the Interop Labs team by filling out the [Axelar Amplifier Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSchD7P1WfdSCQfaZAoqX7DyqJOqYKxXle47yrueTbOgkKQDiQ/viewform). The team will register the chain and gateway with the router and authorize the prover.
+Send the chain’s gateway and multisig prover contract addresses to the Interop Labs team by filling out the [Axelar Amplifier Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSchD7P1WfdSCQfaZAoqX7DyqJOqYKxXle47yrueTbOgkKQDiQ/viewform). The team will register the chain and gateway with the router and authorize the prover.
 
 ## Add verifiers to your chain
 

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -24,8 +24,9 @@ Other info can be found in [`devnet-amplifier.json`](https://github.com/axelarne
 
 Install the `v0.35.5 axelard` binary. You can either download the pre-built version or build it yourself from `axelar-core`.
 
-### Option 1: Download the pre-built binary
+<tabs>
 
+<tab-item title="Download">
 1. Download the pre-built [`axelard` binary](https://github.com/axelarnetwork/axelar-core/releases/tag/v0.35.5) along with the latest version of the [`WasmVM`](https://github.com/CosmWasm/wasmvm/releases/tag/v1.3.1).
     - Intel Macs: [`axelard-darwin-amd64-v0.35.5`](https://github.com/axelarnetwork/axelar-core/releases/download/v0.35.5/axelard-darwin-amd64-v0.35.5) and [`libwasmvm.dylib`](https://github.com/CosmWasm/wasmvm/releases/download/v1.3.1/libwasmvm.dylib)
     - [Macs with Apple silicon](https://support.apple.com/en-us/116943): [`axelard-darwin-arm64-v0.35.5`](https://github.com/axelarnetwork/axelar-core/releases/download/v0.35.5/axelard-darwin-arm64-v0.35.5) and [`libwasmvm.dylib`](https://github.com/CosmWasm/wasmvm/releases/download/v1.3.1/libwasmvm.dylib)
@@ -45,9 +46,9 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
     ```bash
     xattr -d com.apple.quarantine [filename]
     ```
+</tab-item>
 
-### Option 2: Build the binary yourself
-
+<tab-item title="Build">
 1. Clone the [`axelar-core` repo](https://github.com/axelarnetwork/axelar-core).
 1. Checkout the `v0.35.5` release tag.
 1. Run `make build`.
@@ -68,12 +69,14 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
     !faucet devnet-amplifier [your axelar wallet address]
     ```
 
-
 1. Query your account balance by running:
 
     ```bash
     axelard q bank balances [your axelar wallet address] --node http://devnet-amplifier.axelar.dev:26657
     ```
+</tab-item>
+
+</tabs>
 
 ## Onboard a chain to Amplifier
 
@@ -81,16 +84,16 @@ Once you are running `ampd` and `tofnd`, you can onboard a chain to the Amplifie
 
 You can either use the existing deployed contracts and on the devnet via their `code_id`s, or build and store these contracts from the `axelar-examples` repo. A `code_id` is a CosmWasm identifier of a stored contract that can be instantiated. **You will need to instantiate the contracts no matter which option you choose.**
 
-### Option 1: Use existing deployed contracts
-
+<tabs>
+<tab-item title="Use pre-deployed contracts">
 Use the existing deployments for all three contracts, making note of the existing deployment's `code_id`:
 
 - Voting verifier (code_id: `500`)
 - Gateway (code_id: `493`)
 - Mutisig prover (code_id: `495`)
+</tab-item>
 
-### Option 2: Build and deploy the contracts yourself
-
+<tab-item title="Build and deploy contracts">
 1. Clone the [`axelar-amplifier` repo](https://github.com/axelarnetwork/axelar-amplifier).
 
     ```bash
@@ -195,9 +198,9 @@ Use the existing deployments for all three contracts, making note of the existin
     ```
 
     Remember to save your `code_id`.
+</tab-item>
 
-### Option 3: Deploy a custom implementation of the Amplifier contracts
-
+<tab-item title="Use custom implementation">
 You can also deploy a custom implementation of the gateway, verifier, and prover contracts and optimize them with the [`Cosmwasm rust-optimizer`](https://github.com/CosmWasm/optimizer). Follow the same steps as Option 2 with your own implementations of the Amplifier contracts.
 
 ## Instantiate the contracts
@@ -346,6 +349,9 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
 
 
 1. Send the chain’s gateway and multisig prover contract addresses to the Interop Labs team by filling out the [Axelar Amplifier Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSchD7P1WfdSCQfaZAoqX7DyqJOqYKxXle47yrueTbOgkKQDiQ/viewform). The team will register the chain and gateway with the router and authorize the prover.
+</tab-item>
+
+</tabs>
 
 ## Add verifiers to your chain
 
@@ -354,4 +360,3 @@ Every new chain will need a verifier, which requires running `ampd` and `tofnd`.
 ## Begin routing messages
 
 Once your chain is registered with the protocol, it will need verifiers to begin routing messages. See [Become an Amplifier Verifier (Worker)](/validator/amplifier/verifier-onboarding) for instructions to onboard a verifier. Note that chain integrators will onboard on `devnet-amplifier` and not `devnet-verifier`.
-

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -96,7 +96,7 @@ Use the existing deployments for all three contracts, making note of the existin
     ```bash
     git clone https://github.com/axelarnetwork/axelar-amplifier
     cd axelar-amplifier
-    git checkout ampd-v0.4.0
+    git checkout ampd-v0.6.0
     ```
 
 1. Build the `gateway`, `voting verifier`, and `multisig prover` contracts from using the [CosmWasm `rust-optimizer`](https://github.com/CosmWasm/optimizer). From the root of the repo, run:

--- a/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/pages/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -9,7 +9,6 @@ The Axelar Virtual Machine (AVM) and Amplifier are currently under active develo
 ## Prerequisites
 
 - You should know how to deploy and interact with a CosmWasm contract. Refer to the [Osmosis CosmWasm testnet deployment tutorial](https://docs.osmosis.zone/cosmwasm/testnet/cosmwasm-deployment/) if you’d like a refresher — just replace `osmosisid` with `axelard` and use the `amd64` version if building on Linux and `arm64` version of the [contract optimizer](https://github.com/CosmWasm/optimizer) if you are working on a [Mac with Apple silicon](https://support.apple.com/en-us/116943). 
-- Run `--gas auto --gas-adjustment 1.5` to provide your transactions with sufficient gas.
 
 ## Devnet information
 
@@ -17,8 +16,7 @@ The Axelar Virtual Machine (AVM) and Amplifier are currently under active develo
 - Devnet LCD (REST API/JSON RPC): `http://devnet-amplifier.axelar.dev:1317`
 - Devnet gRPC: `devnet-amplifier.axelar.dev:9090`
 - Chain ID: `devnet-amplifier`
-
-Other info can be found in [`devnet-amplifier.json`](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/devnet-amplifier.json).
+- Connected chains and contracts: [`devnet-amplifier.json`](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/axelar-chains-config/info/devnet-amplifier.json)
 
 ## Get the `axelard` binary
 
@@ -27,6 +25,8 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
 <tabs>
 
 <tab-item title="Download">
+To use the pre-built `axelard` binary:
+
 1. Download the pre-built [`axelard` binary](https://github.com/axelarnetwork/axelar-core/releases/tag/v0.35.5) along with the latest version of the [`WasmVM`](https://github.com/CosmWasm/wasmvm/releases/tag/v1.3.1).
     - Intel Macs: [`axelard-darwin-amd64-v0.35.5`](https://github.com/axelarnetwork/axelar-core/releases/download/v0.35.5/axelard-darwin-amd64-v0.35.5) and [`libwasmvm.dylib`](https://github.com/CosmWasm/wasmvm/releases/download/v1.3.1/libwasmvm.dylib)
     - [Macs with Apple silicon](https://support.apple.com/en-us/116943): [`axelard-darwin-arm64-v0.35.5`](https://github.com/axelarnetwork/axelar-core/releases/download/v0.35.5/axelard-darwin-arm64-v0.35.5) and [`libwasmvm.dylib`](https://github.com/CosmWasm/wasmvm/releases/download/v1.3.1/libwasmvm.dylib)
@@ -48,7 +48,9 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
     ```
 </tab-item>
 
-<tab-item title="Build">
+<tab-item title="Build from source">
+To build the `axelard` binary from source:
+
 1. Clone the [`axelar-core` repo](https://github.com/axelarnetwork/axelar-core).
 1. Checkout the `v0.35.5` release tag.
 1. Run `make build`.
@@ -78,11 +80,11 @@ Install the `v0.35.5 axelard` binary. You can either download the pre-built vers
 
 </tabs>
 
-## Onboard a chain to Amplifier
+## Onboard a chain with Amplifier
 
-Once you are running `ampd` and `tofnd`, you can onboard a chain to the Amplifier by instantiating the `gateway`, `voting verifier`, and `multisig prover` contracts.
+Once you are running `ampd` and `tofnd`, you can onboard a chain with the Amplifier by instantiating the `gateway`, `voting verifier`, and `multisig prover` contracts.
 
-You can either use the existing deployed contracts and on the devnet via their `code_id`s, or build and store these contracts from the `axelar-examples` repo. A `code_id` is a CosmWasm identifier of a stored contract that can be instantiated. **You will need to instantiate the contracts no matter which option you choose.**
+You can either use the existing deployed contracts and on the devnet via their `code_id`s (CosmWasm identifiers for stored contracts that can be instantiated), or build and store these contracts from the `axelar-examples` repo. **You will need to instantiate the contracts no matter which option you choose.**
 
 <tabs>
 <tab-item title="Use pre-deployed contracts">
@@ -183,7 +185,7 @@ Use the existing deployments for all three contracts, making note of the existin
         --node http://devnet-amplifier.axelar.dev:26657
     ```
 
-    Remember to save your `code_id`.
+    Remember to save your `code_id`s.
 
 
 1. Deploy the multisig prover:
@@ -197,11 +199,14 @@ Use the existing deployments for all three contracts, making note of the existin
         --node http://devnet-amplifier.axelar.dev:26657
     ```
 
-    Remember to save your `code_id`.
+    Remember to save your `code_id`s.
 </tab-item>
 
 <tab-item title="Use custom implementation">
 You can also deploy a custom implementation of the gateway, verifier, and prover contracts and optimize them with the [`Cosmwasm rust-optimizer`](https://github.com/CosmWasm/optimizer). Follow the same steps as Option 2 with your own implementations of the Amplifier contracts.
+</tab-item>
+
+</tabs>
 
 ## Instantiate the contracts
         
@@ -349,9 +354,6 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
 
 
 1. Send the chain’s gateway and multisig prover contract addresses to the Interop Labs team by filling out the [Axelar Amplifier Integration Form](https://docs.google.com/forms/d/e/1FAIpQLSchD7P1WfdSCQfaZAoqX7DyqJOqYKxXle47yrueTbOgkKQDiQ/viewform). The team will register the chain and gateway with the router and authorize the prover.
-</tab-item>
-
-</tabs>
 
 ## Add verifiers to your chain
 


### PR DESCRIPTION
- Add tabs
- Bump ampd version to 0.6.0

Preview: https://axelar-docs-git-marty-update-chain-int-tutorial-axelar-network.vercel.app/dev/amplifier/chain-integration/integrate-a-chain