### PR TITLE
fix: remove actual chains from config.toml

### DIFF
--- a/src/pages/validator/amplifier/verifier-onboarding.mdx
+++ b/src/pages/validator/amplifier/verifier-onboarding.mdx
@@ -240,32 +240,18 @@ The following are an example `config.toml` files:
     type="MultisigSigner"
     
     [[handlers]]
-    chain_name="ethereum-sepolia"
-    chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-    cosmwasm_contract="axelar1sxujcvele5eqtx0xc4wuy6jr0m28y0yt8spn7efc3527vc2j2xrqk6wkay"
+    chain_name="YOUR_CHAIN_NAME"
+    chain_rpc_url="YOUR_CHAIN_RPC_URL"
+    cosmwasm_contract="YOUR_VOTING_VERIFIER"
     type="EvmMsgVerifier"
-    chain_finalization="RPCFinalizedBlock"
+    chain_finalization="YOUR_CONFIRMATION_HEIGHT"
     
     [[handlers]]
-    chain_name="ethereum-sepolia"
-    chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-    cosmwasm_contract="axelar1sxujcvele5eqtx0xc4wuy6jr0m28y0yt8spn7efc3527vc2j2xrqk6wkay"
+    chain_name="YOUR_CHAIN_NAME"
+    chain_rpc_url="YOUR_CHAIN_RPC_URL"
+    cosmwasm_contract="YOUR_VOTING_VERIFIER"
     type="EvmVerifierSetVerifier"
-    chain_finalization="RPCFinalizedBlock"
-    
-    [[handlers]]
-    chain_name="avalanche"
-    chain_rpc_url="https://avalanche-fuji-c-chain-rpc.publicnode.com"
-    cosmwasm_contract="axelar1elaymnd2epmfr498h2x9p2nezc4eklv95uv92u9csfs8wl75w7yqdc0h67"
-    type="EvmMsgVerifier"
-    chain_finalization="ConfirmationHeight"
-    
-    [[handlers]]
-    chain_name="avalanche"
-    chain_rpc_url="https://avalanche-fuji-c-chain-rpc.publicnode.com"
-    cosmwasm_contract="axelar1elaymnd2epmfr498h2x9p2nezc4eklv95uv92u9csfs8wl75w7yqdc0h67"
-    type="EvmVerifierSetVerifier"
-    chain_finalization="ConfirmationHeight"
+    chain_finalization="YOUR_CONFIRMATION_HEIGHT"
     ```
 </tab-item>
 <tab-item title="devnet-amplifier">
@@ -298,30 +284,18 @@ The following are an example `config.toml` files:
    type="MultisigSigner"
 
    [[handlers]]
-   chain_name="ethereum-sepolia"
-   chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-   cosmwasm_contract="axelar1e6jnuljng6aljk0tjct6f0hl9tye6l0n9p067pwx2374h82dmr0s9qcqy9"
+   chain_name="YOUR_CHAIN_NAME"
+   chain_rpc_url="YOUR_CHAIN_RPC_URL"
+   cosmwasm_contract="YOUR_VOTING_VERIFIER"
    type="EvmMsgVerifier"
-   chain_finalization="RPCFinalizedBlock"
+   chain_finalization="YOUR_CONFIRMATION_HEIGHT"
 
    [[handlers]]
-   chain_name="ethereum-sepolia"
-   chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-   cosmwasm_contract="axelar1e6jnuljng6aljk0tjct6f0hl9tye6l0n9p067pwx2374h82dmr0s9qcqy9"
+   chain_name="YOUR_CHAIN_NAME"
+   chain_rpc_url="YOUR_CHAIN_RPC_URL"
+   cosmwasm_contract="YOUR_VOTING_VERIFIER"
    type="EvmVerifierSetVerifier"
-
-   [[handlers]]
-   chain_name="avalanche"
-   chain_rpc_url="https://avalanche-fuji-c-chain-rpc.publicnode.com"
-   cosmwasm_contract="axelar1ty7mx0cllgz8xuvhn2j7e3qy8999ssgmjtktyqetl335em0g88lq6rjhl2"
-   type="EvmMsgVerifier"
-   chain_finalization="RPCFinalizedBlock"
-
-   [[handlers]]
-   chain_name="avalanche"
-   chain_rpc_url="https://avalanche-fuji-c-chain-rpc.publicnode.com"
-   cosmwasm_contract="axelar1ty7mx0cllgz8xuvhn2j7e3qy8999ssgmjtktyqetl335em0g88lq6rjhl2"
-   type="EvmVerifierSetVerifier"
+   chain_finalization="YOUR_CONFIRMATION_HEIGHT"
    ```
 </tab-item>
 <tab-item title="testnet">
@@ -355,32 +329,18 @@ The following are an example `config.toml` files:
    type="MultisigSigner"
 
    [[handlers]]
-   chain_name="test-sepolia"
-   chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-   cosmwasm_contract="axelar1r4rmvn83vrfj4evy5l8cv2nat2v0whm36ds3crn2mhlq8ufmhvts9467zz"
-   chain_finalization="RPCFinalizedBlock"
-   type="EvmMsgVerifier"
-
-   [[handlers]]
-   chain_name="test-sepolia"
-   chain_rpc_url="https://rpc.ankr.com/eth_sepolia"
-   cosmwasm_contract="axelar1r4rmvn83vrfj4evy5l8cv2nat2v0whm36ds3crn2mhlq8ufmhvts9467zz"
-   chain_finalization="RPCFinalizedBlock"
+   chain_name="YOUR_CHAIN_NAME"
+   chain_rpc_url="YOUR_CHAIN_RPC_URL"
+   cosmwasm_contract="YOUR_VOTING_VERIFIER"
    type="EvmVerifierSetVerifier"
+   chain_finalization="YOUR_CONFIRMATION_HEIGHT"
 
    [[handlers]]
-   chain_name="test-avalanche"
-   chain_rpc_url="https://api.avax-test.network/ext/bc/C/rpc"
-   cosmwasm_contract="axelar1hupk5du59cgu4ps5s637rhakwsq0060ycdp57j2ccevna7wqqzrqnfrr0p"
-   chain_finalization="ConfirmationHeight"
+   chain_name="YOUR_CHAIN_NAME"
+   chain_rpc_url="YOUR_CHAIN_RPC_URL"
+   cosmwasm_contract="YOUR_VOTING_VERIFIER"
    type="EvmMsgVerifier"
-
-   [[handlers]]
-   chain_name="test-avalanche"
-   chain_rpc_url="https://api.avax-test.network/ext/bc/C/rpc"
-   cosmwasm_contract="axelar1hupk5du59cgu4ps5s637rhakwsq0060ycdp57j2ccevna7wqqzrqnfrr0p"
-   chain_finalization="ConfirmationHeight"
-   type="EvmVerifierSetVerifier"
+   chain_finalization="YOUR_CONFIRMATION_HEIGHT"
 
    # For each supported chain
    #[[handlers]]


### PR DESCRIPTION
Preview: https://axelar-docs-git-marty-update-verifier-configs-axelar-network.vercel.app/validator/amplifier/verifier-onboarding/

Extra verifiers were added to `devnet-amplifier` that did not correspond to our pods. They were likely added by chain integrators who copied and pasted the `config.toml` file from docs when integrating their own chains. This fix removes that from happening.

See [Slack thread](https://interoplabs.slack.com/archives/C04K4J95GKC/p1724691113379569) for more details.