### PR TITLE
fix: AxelarJS transaction recovery doc

### DIFF
--- a/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
+++ b/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
@@ -1,10 +1,22 @@
-# Query and recover GMP transactions
+# Programmatically query and recover GMP transactions
 
-Occasionally, transactions can get "stuck" in the pipeline from a source to destination chain (e.g. due to one-off issues that arise with relayers that operate on top of the network).
+import { Callout } from "/src/components/callout"
 
-The `AxelarGMPRecoveryAPI` module in the AxelarJS SDK can be used by your dApp to query the status of any General Message Passing (GMP) transaction (triggered by either `callContract` or `callContractWithToken`) on the gateway contract of a source chain and trigger a manual relay from source to destination if necessary. - The [GMP status tracker](/dev/general-message-passing/debug/transaction-recovery/) on Axelarscan makes use of this feature.
+Transactions can occasionally get stuck in the pipeline from a source to destination chain, mostly from one of the two following reasons:
 
-### Install the AxelarJS SDK module (`AxelarGMPRecoveryAPI`)
+- The transaction is not relayed from the source chain into the Axelar network for processing.
+- The transaction fails to get executed on the destination chain.
+
+The [`AxelarGMPRecoveryAPI`](https://github.com/axelarnetwork/axelarjs-sdk/blob/main/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts) module in the AxelarJS SDK can be used to troubleshoot:
+
+- Query the status of any General Message Passing (GMP) transaction for either `callContract()` or `callContractWithToken()` on the gateway contract of a source chain.
+- Trigger a manual relay from the source chain to the destination chain.
+
+<Callout>
+Transaction recovery can also be invoked through the [Axelarscan UI](/dev/general-message-passing/debug/transaction-recovery/).
+</Callout>
+
+## Install the `AxelarGMPRecoveryAPI` module
 
 Install the AxelarJS SDK:
 
@@ -12,7 +24,7 @@ Install the AxelarJS SDK:
 npm i @axelar-network/axelarjs-sdk
 ```
 
-Instantiate the `AxelarGMPRecoveryAPI` module:
+Instantiate the [`AxelarGMPRecoveryAPI`](https://github.com/axelarnetwork/axelarjs-sdk/blob/main/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts) module:
 
 ```ts
 import {
@@ -25,38 +37,55 @@ const sdk = new AxelarGMPRecoveryAPI({
 });
 ```
 
-### Query transaction status by txHash
+## Query transaction status by `txHash`
 
-Invoke `queryTransactionStatus`:
+See the status of a transaction by passing its `txHash` into [`queryTransactionStatus()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts#L226):
 
 ```ts
 const txHash: string =
   "0xfb6fb85f11496ef58b088116cb611497e87e9c72ff0c9333aa21491e4cdd397a";
-const txStatus: GMPStatusResponse = await sdk.queryTransactionStatus(txHash);
+const eventIndex: number = 97
+const txStatus: GMPStatusResponse = await sdk.queryTransactionStatus(txHash, eventIndex);
 ```
 
-Possible status responses for txStatus are outlined below:
+The following are possible status responses:
 
 ```ts
 interface GMPStatusResponse {
-  status: GMPStatus;
+  status: GMPStatus | string;
+  timeSpent?: Record<string, number>;
   gasPaidInfo?: GasPaidInfo;
-  errors?: any;
-  callData?: any;
+  error?: GMPError;
+  callTx?: any;
+  executed?: any;
+  expressExecuted?: any;
+  approved?: any;
+  callback?: any;
 }
+
 enum GMPStatus {
   SRC_GATEWAY_CALLED = "source_gateway_called",
   DEST_GATEWAY_APPROVED = "destination_gateway_approved",
   DEST_EXECUTED = "destination_executed",
-  DEST_EXECUTE_ERROR = "destination_execute_error",
+  EXPRESS_EXECUTED = "express_executed",
+  DEST_EXECUTE_ERROR = "error",
   DEST_EXECUTING = "executing",
+  APPROVING = "approving",
+  FORECALLED = "forecalled",
+  FORECALLED_WITHOUT_GAS_PAID = "forecalled_without_gas_paid",
+  NOT_EXECUTED = "not_executed",
+  NOT_EXECUTED_WITHOUT_GAS_PAID = "not_executed_without_gas_paid",
+  INSUFFICIENT_FEE = "insufficient_fee",
   UNKNOWN_ERROR = "unknown_error",
-  CANNOT_FETCH_STATUS = "cannot_fetch_status"
+  CANNOT_FETCH_STATUS = "cannot_fetch_status",
+  SRC_GATEWAY_CONFIRMED = "confirmed"
 }
+
 interface GasPaidInfo {
   status: GasPaidStatus;
   details?: any;
 }
+
 enum GasPaidStatus {
   GAS_UNPAID = "gas_unpaid",
   GAS_PAID = "gas_paid",
@@ -65,12 +94,9 @@ enum GasPaidStatus {
 }
 ```
 
-### Trigger manual relay of transaction through the Axelar network
+## Manually relay the transaction through the Axelar network
 
-The following method, once invoked, will:
-
-1. Query the current status of the transaction to be in one of the states above.
-2. Recover from source to destination if needed.
+Use [`manualRelayToDestChain()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts#L453) to manually relay a transaction to the destination chain through the Axelar network. It will query the current transaction status and recover from source to destination if needed.
 
 ```ts
 const sourceTxHash = "0x..";
@@ -92,7 +118,7 @@ const response = await sdk.manualRelayToDestChain(
 Possible response values are:
 
 ```ts
-export interface ApproveGatewayResponse {
+interface ApproveGatewayResponse {
   success: boolean;
   error?: ApproveGatewayError | string;
   confirmTx?: AxelarTxResponse;
@@ -102,13 +128,11 @@ export interface ApproveGatewayResponse {
 }
 ```
 
-If `success == false` in the response above, there are two options to remediate (below). 
+If `success == false`, you can either execute the transaction manually or increase the gas payment.
 
-### Execute manually OR increase gas payment
+## Manually execute a transaction
 
-#### 1. Execute manually
-
-When invoking this method, you will manually execute (and pay for) the executable method on your specified contract on the destination chain of your cross-chain transaction.
+When invoking this method, you will manually execute and pay for the executable method on your specified contract on the destination chain of your cross-chain transaction.
 
 ```ts
 const sourceTxHash = "0x..";
@@ -137,13 +161,13 @@ Possible response values are:
 }
 ```
 
-#### 2. Increase gas payment
+## Increase gas payment
 
-There are two different functions to increase gas payment depending on type of the token.
+You can increase the gas payment using a native token or an ERC-20 token.
 
-##### 2.1 Native gas payment
+### Native gas payment
 
-Invoking this method will execute the `addNativeGas` method on the Gas Receiver contract on the source chain of your cross-chain transaction to increase the amount of the gas payment, in the source chain native token. The amount to be added is automatically calculated based on many factors e.g. token price of the destination chain, token price of the source chain, current gas price at the destination chain, etc. However, it can be overridden by specifying amount in the `options`.
+Invoking this method will execute the `addNativeGas()` method on the `GasReceiver` contract on the source chain of your cross-chain transaction to increase the amount of the gas payment in the source chain native token. The amount to be added is automatically calculated based on many factors, such as the token price of the source and destination chains and the current gas price at the destination chain. This can be overridden by specifying the amount in the `options`.
 
 ```ts
 import {
@@ -164,6 +188,7 @@ const txHash: string = "0x...";
 const { success, transaction, error } = await api.addNativeGas(
   EvmChain.AVALANCHE,
   txHash,
+  estimatedGasUsed,
   options
 );
 
@@ -184,9 +209,9 @@ Possible response values are:
 }
 ```
 
-##### 2.2 ERC-20 Gas Payment
+### ERC-20 gas payment
 
-This is similar to native gas payment except using **ERC-20 token** for gas payment. However, the supported ERC-20 tokens are limited. See the list of supported tokens here: [[Mainnet](/resources/contract-addresses/mainnet/) | [Testnet](/resources/contract-addresses/testnet/)]
+Use an ERC-20 token for gas payment. Supported tokens are limited on the [testnet](/resources/contract-addresses/testnet/) and [mainnet](/resources/contract-addresses/mainnet/).
 
 ```ts
 import {

--- a/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
+++ b/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
@@ -5,7 +5,7 @@ import { Callout } from "/src/components/callout"
 Transactions can occasionally get stuck in the pipeline from a source to destination chain, mostly for one of the two following reasons:
 
 - The transaction is not relayed from the source chain into the Axelar network for processing.
-- The transaction fails to get executed on the destination chain.
+- The transaction fails to get executed on the destination chain due to flawed contract logic. 
 
 The [`AxelarGMPRecoveryAPI`](https://github.com/axelarnetwork/axelarjs-sdk/blob/main/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts) module in the AxelarJS SDK can be used to troubleshoot:
 
@@ -39,7 +39,9 @@ const sdk = new AxelarGMPRecoveryAPI({
 
 ## Query transaction status by `txHash`
 
-See the status of a transaction by passing its `txHash` into [`queryTransactionStatus()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts#L226):
+See the status of a transaction by passing its `txHash` into [`queryTransactionStatus()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarRecoveryApi.ts#L226).
+
+The `eventIndex` is an optional parameter that can be passed in to query a specific internal transaction if several transactions have the same `txHash`.
 
 ```ts
 const txHash: string =
@@ -96,7 +98,7 @@ enum GasPaidStatus {
 
 ## Manually relay the transaction through the Axelar network
 
-Use [`manualRelayToDestChain()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts#L453) to manually relay a transaction to the destination chain through the Axelar network. It will query the current transaction status and recover from source to destination if needed.
+Use [`manualRelayToDestChain()`](https://github.com/axelarnetwork/axelarjs-sdk/blob/86bc55224f84f9539dd109e5dfd6b443a116eebe/src/libs/TransactionRecoveryApi/AxelarGMPRecoveryAPI.ts#L453) to dislodge a transaction [stuck at the **Confirm** step](https://testnet.axelarscan.io/gmp/0x111ff754b85538afcfea5aa59d01f976eb9a7b7b45b483c3fb2c48833bf0780d-4). This function will manually relay a transaction to the destination chain through the Axelar network, query the current transaction status, and recover from source to destination if needed.
 
 ```ts
 const sourceTxHash = "0x..";

--- a/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
+++ b/src/pages/dev/axelarjs-sdk/tx-status-query-recovery.mdx
@@ -2,7 +2,7 @@
 
 import { Callout } from "/src/components/callout"
 
-Transactions can occasionally get stuck in the pipeline from a source to destination chain, mostly from one of the two following reasons:
+Transactions can occasionally get stuck in the pipeline from a source to destination chain, mostly for one of the two following reasons:
 
 - The transaction is not relayed from the source chain into the Axelar network for processing.
 - The transaction fails to get executed on the destination chain.
@@ -118,13 +118,14 @@ const response = await sdk.manualRelayToDestChain(
 Possible response values are:
 
 ```ts
-interface ApproveGatewayResponse {
+export interface GMPRecoveryResponse {
   success: boolean;
   error?: ApproveGatewayError | string;
   confirmTx?: AxelarTxResponse;
-  createPendingTransferTx?: AxelarTxResponse;
   signCommandTx?: AxelarTxResponse;
+  routeMessageTx?: AxelarTxResponse;
   approveTx?: any;
+  infoLogs?: string[];
 }
 ```
 
@@ -163,11 +164,7 @@ Possible response values are:
 
 ## Increase gas payment
 
-You can increase the gas payment using a native token or an ERC-20 token.
-
-### Native gas payment
-
-Invoking this method will execute the `addNativeGas()` method on the `GasReceiver` contract on the source chain of your cross-chain transaction to increase the amount of the gas payment in the source chain native token. The amount to be added is automatically calculated based on many factors, such as the token price of the source and destination chains and the current gas price at the destination chain. This can be overridden by specifying the amount in the `options`.
+Call `addNativeGas()` to increase the gas payment using the source chain's native token. The amount to be added will be automatically calculated based on factors such as the token price of the source and destination chains and the current gas price at the destination chain. This can be overridden by specifying the amount in the `options`.
 
 ```ts
 import {
@@ -196,63 +193,6 @@ if (success) {
   console.log("Added native gas tx:", transaction?.transactionHash);
 } else {
   console.log("Cannot add native gas", error);
-}
-```
-
-Possible response values are:
-
-```ts
-{
-    success: "success" | "failed",
-    data: ethers.ContractReceipt | undefined,
-    error: string | undefined
-}
-```
-
-### ERC-20 gas payment
-
-Use an ERC-20 token for gas payment. Supported tokens are limited on the [testnet](/resources/contract-addresses/testnet/) and [mainnet](/resources/contract-addresses/mainnet/).
-
-```ts
-import {
-  AxelarGMPRecoveryAPI,
-  Environment,
-  AddGasOptions,
-  EvmChain,
-  GAS_RECEIVER,
-} from "@axelar-network/axelarjs-sdk";
-import { ethers } from "ethers";
-
-// Optional
-const options: AddGasOptions = {
-  amount: "10000000", // The amount of gas to be added. If not specified, the sdk will calculate the amount to be paid.
-  refundAddress: "", // The address to get refunded gas. If not specified, the default value is the tx sender address.
-  estimatedGasUsed: 700000, // An amount of gas to execute `executeWithToken` or `execute` function of the custom destination contract. If not specified, the default value is 700000.
-  evmWalletDetails: { useWindowEthereum: true, privateKey: "0x" }, // A wallet to send an `addNativeGas` transaction. If not specified, the default value is { useWindowEthereum: true}.
-};
-
-const environment = Environment.TESTNET; // Can be `Environment.TESTNET` or `Environment.MAINNET`
-const api = new AxelarGMPRecoveryAPI({ environment });
-
-// Approve gas token to the Gas Receiver contract
-const gasToken = "0xGasTokenAddress";
-const erc20 = new ethers.Contract(gasToken, erc20Abi, gasPayer);
-await erc20
-  .approve(GAS_RECEIVER[environment][EvmChain.AVALANCHE], amount)
-  .then((tx) => tx.wait());
-
-// Send `addGas` transaction
-const { success, transaction, error } = await api.addGas(
-  EvmChain.AVALANCHE,
-  "0xSourceTxHash",
-  gasToken,
-  options
-);
-
-if (success) {
-  console.log("Added gas tx:", transaction?.transactionHash);
-} else {
-  console.log("Cannot add gas", error);
 }
 ```
 


### PR DESCRIPTION
- Rewrite to add `eventIndex` to `queryTransactionHash()` method and update enums to reflect current state of APIs. 
- Re-word sections for greater clarity.

Preview: https://axelar-docs-git-marty-axelarjs-sdk-axelar-network.vercel.app/dev/axelarjs-sdk/tx-status-query-recovery/