### PR TITLE
fix: numbering issue under 'Instantiate the contract'

### DIFF
--- a/src/content/docs/dev/amplifier/chain-integration/integrate-a-chain.mdx
+++ b/src/content/docs/dev/amplifier/chain-integration/integrate-a-chain.mdx
@@ -347,7 +347,7 @@ You can also deploy a custom implementation of the gateway, verifier, and prover
         --admin $MY_WALLET_ADDRESS
     ```
 
-The `domain_separator` is a hash of chain name, admin address, and code ID. Value must be a String in hex format without `0x`.
+    The `domain_separator` is a hash of chain name, admin address, and code ID. Value must be a String in hex format without `0x`.
 
 1. Search the output of this command and note the `_contract_address`.
 


### PR DESCRIPTION
Title: "Search the output of this command and note the _contract_address"

This item should be numbered as 3 on the interface, but it is currently being displayed as 1.


<img width="1287" alt="af" src="https://github.com/user-attachments/assets/b095dc9d-2c76-47b0-9ef9-a272c5df761d">
