### PR TITLE
fix: update contract name to AxelarExecutableWithToken

### DIFF
--- a/src/content/docs/dev/general-message-passing/gmp-tokens-with-messages.mdx
+++ b/src/content/docs/dev/general-message-passing/gmp-tokens-with-messages.mdx
@@ -14,7 +14,7 @@ import { Callout } from "/src/components/callout";
 To call chain B from chain A and send some tokens along the way, the user needs to call `callContractWithToken` on the gateway of chain A, specifying:
 
 - The destination chain, which must be an EVM chain from [Chain names](/dev/reference/mainnet-chain-names/).
-- The destination contract address, which must inherit from `AxelarExecutable` defined in [AxelarExecutable.sol](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/executable/AxelarExecutable.sol).
+- The destination contract address, which must inherit from `AxelarExecutableWithToken` defined in [AxelarExecutableWithToken.sol](https://github.com/axelarnetwork/axelar-gmp-sdk-solidity/blob/main/contracts/executable/AxelarExecutableWithToken.sol).
 - The payload `bytes` to pass to the destination contract.
 - The symbol of the token to transfer, which must be a supported asset ([Mainnet](/resources/contract-addresses/mainnet/) | [Testnet](/resources/contract-addresses/testnet/)).
 - The amount of the token to transfer.
@@ -38,7 +38,7 @@ function callContractWithToken(
 ) external;
 ```
 
-`AxelarExecutable` has an `executeWithToken` function that will be triggered by the Axelar network on the destination chain after the `callContractWithToken` function has been executed on the source chain. This will validate the contract call and then invoke _your_ `_executeWithToken` method, where you should write any custom logic.
+`AxelarExecutableWithToken` has an `executeWithToken` function that will be triggered by the Axelar network on the destination chain after the `callContractWithToken` function has been executed on the source chain. This will validate the contract call and then invoke _your_ `_executeWithToken` method, where you should write any custom logic.
 
 The destination contract will be authorized to transfer the ERC-20 identified by the `tokenSymbol`.
 


### PR DESCRIPTION
['Send Messages with Tokens'](https://docs.axelar.dev/dev/general-message-passing/gmp-tokens-with-messages/#call-a-contract-on-chain-b-from-chain-a-and-attach-some-tokens) section tells `AxelarExecutable` is required, but this actually needs to be `AxelarExecutableWithToken` because we are sending a token with the message.