### PR TITLE
Fix bash snippets for adding rewards to pools

### DIFF
--- a/src/content/docs/dev/amplifier/add-rewards.mdx
+++ b/src/content/docs/dev/amplifier/add-rewards.mdx
@@ -62,12 +62,13 @@ Use `add_rewards()` add funds to a pool:
 
 <tab-item title="<code>devnet-amplifier</code>">
 
-  ```bash export
-  REWARDS_CONTRACT_ADDRESS="axelar1vaj9sfzc3z0gpel90wu4ljutncutv0wuhvvwfsh30rqxq422z89qnd989l"
-    export CHAIN_NAME="avalanche" export
-  VOTING_VERIFIER_OR_MULTISIG_CONTRACT_ADDRESS="axelar1elaymnd2epmfr498h2x9p2nezc4eklv95uv92u9csfs8wl75w7yqdc0h67"
-  || "0x7eeE33A59Db27d762AA1Fa31b26efeE0dABa1132" export
-  RPC="http://devnet-amplifier.axelar.dev:26657" export AMOUNT="1000uamplifier"
+  ```bash 
+  export REWARDS_CONTRACT_ADDRESS="axelar1vaj9sfzc3z0gpel90wu4ljutncutv0wuhvvwfsh30rqxq422z89qnd989l"
+  export CHAIN_NAME="avalanche" 
+  export VOTING_VERIFIER_OR_MULTISIG_CONTRACT_ADDRESS="axelar1elaymnd2epmfr498h2x9p2nezc4eklv95uv92u9csfs8wl75w7yqdc0h67"
+  || "0x7eeE33A59Db27d762AA1Fa31b26efeE0dABa1132" 
+  export RPC="http://devnet-amplifier.axelar.dev:26657" 
+  export AMOUNT="1000uamplifier"
   # choose the amount to fund (1000000 = 1 AXL) export
   CHAIN_ID="devnet-amplifier" 
 ```
@@ -94,9 +95,9 @@ axelard tx wasm execute $REWARDS_CONTRACT_ADDRESS \
                     }
             }
     }' \
-    --amount '"$AMOUNT"' \
+    --amount $AMOUNT \
     --keyring-backend test \
-    --chain-id "'"$CHAIN_ID"'" \
+    --chain-id $CHAIN_ID \
     --from wallet \
     --gas auto --gas-adjustment 1.5 --gas-prices 0.007uamplifier \
     --node $RPC


### PR DESCRIPTION
Some lines in the bash snippets for executing an `add_rewards()` call to a rewards pool were malformed

Fixed for clarity & improved devX