### PR TITLE
Fix Discord Link

### DIFF
--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -4,7 +4,7 @@ import Logo from "../logo";
 const socials = {
   twitter: "https://twitter.com/axelar",
   instagram: "https://t.me/axelarcommunity",
-  discord: "https://discord.com/invite/axelar-network",
+  discord: "https://discord.com/invite/axelar",
   facebook: "https://twitter.com/axelar",
 };
 


### PR DESCRIPTION
Reported on Telegram:



> "scroll down, bottom there is a discord icon
> redirects to a discord server (prob a scam server) that asks verification though a third party  third patry asks to send a tx in my case on eth network, whick tried to get all my cETH (compound eth = eth staked on compound protocol)"

