### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -2,10 +2,10 @@
 import Logo from "../logo";
 
 const socials = {
-  twitter: "https://twitter.com/axelar",
+  twitter: "https://x.com/axelar",
   instagram: "https://t.me/axelarcommunity",
   discord: "https://discord.com/invite/axelar",
-  facebook: "https://twitter.com/axelar",
+  facebook: "https://x.com/axelar",
 };
 
 const links = [
@@ -39,7 +39,7 @@ const links = [
     items: [
       {
         title: "X (Twitter)",
-        href: "https://twitter.com/axelar",
+        href: "https://x.com/axelar",
       },
       {
         title: "Discord",

--- a/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/link-custom-tokens-deployed-across-multiple-chains-into-interchain-tokens.mdx
+++ b/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/link-custom-tokens-deployed-across-multiple-chains-into-interchain-tokens.mdx
@@ -694,7 +694,7 @@ Check the [Axelarscan testnet scanner](https://testnet.axelarscan.io/) to see if
 
 You have now programmatically linked custom tokens deployed on multiple chains as Interchain Token using Axelar’s Interchain Token Service and transfer it between two chains.
 
-Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://twitter.com/axelarnetwork) on Twitter (X).
+Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://x.com/axelarnetwork) on Twitter (X).
 
 ## What’s next
 

--- a/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/programmatically-create-a-canonical-token.mdx
+++ b/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/programmatically-create-a-canonical-token.mdx
@@ -482,7 +482,7 @@ You can also import the new token into your own wallet with its contract address
 
 You have now programmatically created a Canonical Interchain Token using Axelar’s Interchain Token Service and transferred it between two chains. You should now be able to confidently create and manage your own Interchain Tokens, opening up a wide range of possibilities for token transfers and asset bridges.
 
-Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://twitter.com/axelarnetwork) on Twitter (X).
+Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://x.com/axelarnetwork) on Twitter (X).
 
 ## What’s next
 

--- a/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/programmatically-create-a-token.mdx
+++ b/src/content/docs/dev/send-tokens/interchain-tokens/developer-guides/programmatically-create-a-token.mdx
@@ -480,7 +480,7 @@ You can also import the new token into your own wallet with its contract address
 
 You have now programmatically created a new interchain token called NIT using Axelar’s Interchain Token Service and transferred it between two chains. You should now be able to confidently create and manage your own Interchain Tokens, opening up a wide range of possibilities for token transfers and asset bridges.
 
-Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://twitter.com/axelarnetwork) on Twitter (X).
+Great job making it this far! To show your support to the author of this tutorial, please post about your experience and tag [@axelarnetwork](https://x.com/axelarnetwork) on Twitter (X).
 
 ## What’s next
 


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.