### PR TITLE
Update axelard mainnet to v1.1.3

### DIFF
--- a/src/config/variables.ts
+++ b/src/config/variables.ts
@@ -1,4 +1,4 @@
-export const AXELARD = "1.0.5";
+export const AXELARD = "1.1.3";
 export const AXELARD_TESTNET = "1.1.2";
 export const AMPD = "1.3.1";
 export const TOFND = "1.0.1";


### PR DESCRIPTION
The [documentation](https://docs.axelar.dev/resources/contract-addresses/mainnet/) still shows `v1.0.5` as the latest version to use, and some node-operators have been having trouble with syncing up their nodes because of that.