### PR TITLE
fix: update XRPL node setup guide

### DIFF
--- a/src/content/docs/validator/external-chains/xrpl.mdx
+++ b/src/content/docs/validator/external-chains/xrpl.mdx
@@ -7,10 +7,10 @@ Node setup guide for your XRP Ledger Testnet or Mainnet validator.
 ## Requirements
 
 - [Set up your Amplifier verifier node](https://docs.axelar.dev/validator/amplifier/verifier-onboarding/)
-- Minimum hardware requirements:
-    * CPU: Quad core x86_64 (64-bit)
-    * Memory: 16 GB+ RAM
-    * Disk: 50 GB SSD/NVMe
+- Recommended hardware requirements:
+    * CPU: 3+ GHz 64-bit x86_64 processor with 8+ cores
+    * Memory: 64 GB RAM
+    * Disk: 50+ GB SSD/NVMe
 - Ubuntu Linux 18.04+ (tested on 22.04) or Debian 10+
 - [Official Documentation](https://xrpl.org/docs/infrastructure/installation)
 
@@ -91,7 +91,7 @@ Edit your `rippled.cfg` file located under `/etc/opt/ripple/rippled.cfg`.
 
 ```
 [ips]
-s.altnet.rippletest.net 51235
+r.altnet.rippletest.net 51235
 ```
 
 2. Comment out the previous `[ips]` stanza, if there is one.


### PR DESCRIPTION
* Include recommended hardware requirements instead of minimum.
* Update the `[ips]` stanza for the new rippled version`2.4.0`.