### PR TITLE
feat: New logic to add Manual meta descriptions + title, remove hidden/unused page links from sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,17 @@ export default defineConfig({
       priority: 0.9,
       changefreq: "daily",
       lastmod: new Date(),
+      filter: (page) => {
+        const excludeUrls = [
+          "/controller/deploy-token/",
+          "/controller/add-evm-chain/",
+          "/dev/indexers/subquery/",
+          "/dev/indexers/overview/",
+          "/node/join-old/",
+        ];
+
+        return !excludeUrls.some((url) => page.endsWith(url));
+      },
     }),
     tailwind(),
     partytown({

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,6 +3,7 @@ import { defineCollection, z } from "astro:content";
 const docs = defineCollection({
   schema: z.object({
     title: z.string().optional(),
+    description: z.string().optional(),
   }),
 });
 

--- a/src/content/docs/resources/contract-addresses/mainnet.mdx
+++ b/src/content/docs/resources/contract-addresses/mainnet.mdx
@@ -1,3 +1,8 @@
+---
+title: Axelar Mainnet Contract Addresses
+description: Official Axelar mainnet contract addresses, including gateways and tokens across supported blockchains. Use this reference for secure cross-chain integration.
+---
+
 # Mainnet
 
 import { Callout } from '/src/components/callout';

--- a/src/content/docs/resources/contract-addresses/testnet.mdx
+++ b/src/content/docs/resources/contract-addresses/testnet.mdx
@@ -1,3 +1,8 @@
+---
+title: Axelar Testnet Contract Addresses
+description: Official Axelar testnet contract addresses for gateways, tokens, and infrastructure. Ideal for testing cross-chain integrations before mainnet deployment.
+---
+
 # Testnet
 
 import { Callout } from "/src/components/callout";

--- a/src/content/docs/resources/rpc/resources.mdx
+++ b/src/content/docs/resources/rpc/resources.mdx
@@ -1,3 +1,7 @@
+---
+description: Access public Axelar RPC endpoints and resources for mainnet and testnet. Use these to interact with Axelar's network and build cross-chain applications.
+---
+
 import { Callout } from "/src/components/callout";
 
 import Resources from "/src/components/resources/index.jsx";

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -38,8 +38,8 @@ const firstImage = extractFirstImage(doc.body);
 
 <MainLayout
   image={firstImage}
-  title={headings.find((h) => h.depth === 1)?.text}
-  description={generateMetaDescription(doc.body)}
+  title={doc?.data?.title ?? headings.find((h) => h.depth === 1)?.text}
+  description={doc?.data?.description ?? generateMetaDescription(doc.body)}
 >
   <div class="grid grid-cols-1 lg:grid-cols-12 bg-[#FFFFFF] dark:bg-background">
     <WorldMap className="lg:col-span-9 2xl:col-span-10 w-full flex-1 ">


### PR DESCRIPTION
This PR adds support for manually setting meta descriptions and titles to improve SEO control. It also cleans up the sitemap by removing hidden or unused page links, ensuring only relevant pages are indexed.

follow up PR for SEO enhancements.