### PR TITLE
docs: update working rpc/lcd/grpc endpoints and explorers

### DIFF
--- a/src/content/docs/validator/setup/manual.mdx
+++ b/src/content/docs/validator/setup/manual.mdx
@@ -170,10 +170,23 @@ sed -i.bak 's/external_address = \"\"/external_address = \"'"$(curl -4 ifconfig.
 
 ## Sync From Snapshot
 
+### Mainnet
+
+Pick a snapshot provider:
+
 <tabs>
-<tab-item title="Mainnet">
+<tab-item title="Posthuman">
  ```bash
- axelard tendermint unsafe-reset-all
+axelard tendermint unsafe-reset-all
+cd $HOME/.axelar/
+wget -O - https://snapshots.axelar.posthuman.digital/data_latest.tar.lz4 | lz4 -d | tar -xvf -
+cd $HOME
+```
+
+</tab-item>
+<tab-item title="QuickSync">
+ ```bash
+axelard tendermint unsafe-reset-all
 URL=\`curl -L https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelar-dojo-1-pruned")|.url'\`
 echo $URL
 cd $HOME/.axelar/
@@ -182,18 +195,18 @@ cd $HOME
 ```
 
 </tab-item>
-<tab-item title="Testnet">
- ```bash
+</tabs>
+
+### Testnet
+
+```bash
 axelard tendermint unsafe-reset-all
-URL=\`curl -L https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'\`
+URL=`curl -L https://quicksync.io/axelar.json | jq -r '.[] |select(.file=="axelartestnet-lisbon-3-pruned")|.url'`
 echo $URL
 cd $HOME/.axelar/
 wget -O - $URL | lz4 -d | tar -xvf -
 cd $HOME
 ```
-
-</tab-item>
-</tabs>
 
 ## Create services
 

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -63,6 +63,9 @@
         },
         {
           "value": "https://axelar.rpc.stakin-nodes.com:443"
+        },
+        {
+          "value": "https://rpc.axelar.posthuman.digital:443"
         }
       ]
     },
@@ -80,6 +83,9 @@
         },
         {
           "value": "https://axelar.rest.stakin-nodes.com"
+        },
+        {
+          "value": "https://rest.axelar.posthuman.digital"
         }
       ]
     },
@@ -94,6 +100,9 @@
         },
         {
           "value": "axelar.grpc.stakin-nodes.com:443"
+        },
+        {
+          "value": "grpc.axelar.posthuman.digital:443"
         }
       ]
     },

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -21,24 +21,12 @@
           "value": "https://www.mintscan.io/axelar"
         },
         {
-          "title": "Big Dipper",
-          "value": "https://axelar-mainnet.chainode.tech"
-        },
-        {
-          "title": "Metrika",
-          "value": "https://app.metrika.co/dashboard/axelar"
-        },
-        {
           "title": "Atomscan",
           "value": "https://atomscan.com/axelar"
         },
         {
           "title": "Ping.Pub",
           "value": "https://ping.pub/axelar"
-        },
-        {
-          "title": "ScanRun (beta)",
-          "value": "https://scanrun.io/axelar"
         }
       ]
     },
@@ -58,9 +46,6 @@
     {
       "name": "RPC endpoints",
       "value": [
-        {
-          "value": "https://rpc-axelar.imperator.co:443"
-        },
         {
           "value": "https://axelar-rpc.pops.one:443"
         },
@@ -82,9 +67,6 @@
       "name": "LCD endpoints",
       "value": [
         {
-          "value": "https://lcd-axelar.imperator.co"
-        },
-        {
           "value": "https://axelar-lcd.qubelabs.io"
         },
         {
@@ -92,24 +74,12 @@
         },
         {
           "value": "https://api-axelar.validatrium.club"
-        },
-        {
-          "value": "https://axelar-archrest.chainode.tech"
         }
       ]
     },
     {
       "name": "gRPC endpoints",
       "value": [
-        {
-          "value": "grpc-axelar.imperator.co:443"
-        },
-        {
-          "value": "axelar-archgrpc.chainode.tech"
-        },
-        {
-          "value": "axelar-grpc.quickapi.com"
-        },
         {
           "value": "axelar-grpc.polkachu.com:15190"
         },
@@ -119,27 +89,10 @@
       ]
     },
     {
-      "name": "Archival endpoints",
-      "value": [
-        {
-          "value": "https://axelar-archrpc.chainode.tech"
-        },
-        {
-          "value": "https://axelar-archrest.chainode.tech"
-        },
-        {
-          "value": "https://axelar-archgrpc.chainode.tech"
-        },
-        {
-          "value": "https://axelar-archgrpcweb.chainode.tech"
-        }
-      ]
-    },
-    {
       "name": "Websocket",
       "value": [
         {
-          "value": "wss://rpc-axelar.imperator.co/websocket"
+          "value": "wss://axelar-rpc.pops.one/websocket"
         }
       ]
     }
@@ -177,27 +130,6 @@
         {
           "title": "Discord faucet bot",
           "value": "https://discord.com/channels/770814806105128977/1002423218772136056"
-        },
-        {
-          "title": "Axelar faucet",
-          "value": "https://faucet.testnet.axelar.dev"
-        },
-        {
-          "title": "Faucet by All That Node",
-          "value": "https://www.allthatnode.com/faucet/axelar.dsrv"
-        }
-      ]
-    },
-    {
-      "name": "REST API docs",
-      "value": [
-        {
-          "title": "Swagger",
-          "value": "https://lcd-axelar-testnet.imperator.co/static/"
-        },
-        {
-          "title": "OpenAPI",
-          "value": "https://lcd-axelar-testnet.imperator.co/static/openapi/"
         }
       ]
     },
@@ -205,13 +137,13 @@
       "name": "RPC endpoints",
       "value": [
         {
-          "value": "https://rpc-axelar-testnet.imperator.co:443"
-        },
-        {
-          "value": "https://axelar-rpc-1.staketab.org:443"
-        },
-        {
           "value": "https://axelar-testnet-rpc.qubelabs.io:443"
+        },
+        {
+          "value": "https://axelar-testnet-rpc.polkachu.com:443"
+        },
+        {
+          "value": "https://tm.axelar-testnet.lava.build:443"
         }
       ]
     },
@@ -219,25 +151,13 @@
       "name": "LCD endpoints",
       "value": [
         {
-          "value": "https://lcd-axelar-testnet.imperator.co"
-        },
-        {
-          "value": "https://axelar-rest-1.staketab.org"
-        },
-        {
           "value": "https://axelar-testnet-lcd.qubelabs.io"
-        },
-        {
-          "value": "https://axelar-archrest.chainode.tech"
         }
       ]
     },
     {
       "name": "gRPC endpoints",
-      "value": [ 
-        {
-          "value": "axelar-archgrpc.chainode.tech:443"
-        },
+      "value": [
         {
           "value": "grpc.axelar-testnet.lava.build:443"
         }
@@ -248,9 +168,6 @@
       "value": [
         {
           "value": "wss://tm.axelar-testnet.lava.build/websocket"
-        },
-        {
-          "value": "wss://rpc-axelar-testnet.imperator.co/websocket"
         }
       ]
     }

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -60,6 +60,9 @@
         },
         {
           "value": "https://axelar.publicnode.com:443"
+        },
+        {
+          "value": "https://axelar.rpc.stakin-nodes.com:443"
         }
       ]
     },
@@ -74,6 +77,9 @@
         },
         {
           "value": "https://api-axelar.validatrium.club"
+        },
+        {
+          "value": "https://axelar.rest.stakin-nodes.com"
         }
       ]
     },
@@ -85,6 +91,9 @@
         },
         {
           "value": "axelar-grpc.qubelabs.io:9092"
+        },
+        {
+          "value": "axelar.grpc.stakin-nodes.com:443"
         }
       ]
     },


### PR DESCRIPTION
## RPC/LCD/gRPC endpoint cleanup

  Tested every endpoint in `src/data/resources.json` and removed the ones that no longer respond.

  ### Mainnet

  | Section | Removed | Reason |
  |---|---|---|
  | Block explorers | `Big Dipper` (`axelar-mainnet.chainode.tech`) | Chainode hosts offline |
  | Block explorers | `Metrika` | Removed |
  | Block explorers | `ScanRun (beta)` | Removed |
  | RPC | `https://rpc-axelar.imperator.co:443` | HTTP 502 |
  | LCD | `https://lcd-axelar.imperator.co` | HTTP 502 |
  | LCD | `https://axelar-archrest.chainode.tech` | Connection timeout |
  | gRPC | `grpc-axelar.imperator.co:443` | HTTP 502 |
  | gRPC | `axelar-archgrpc.chainode.tech` | Connection timeout |
  | gRPC | `axelar-grpc.quickapi.com` | HTTP 403 |
  | Archival | entire section (4 chainode hosts) | All connection timeout |
  | Websocket | `wss://rpc-axelar.imperator.co/websocket` | HTTP 502 — replaced with `wss://axelar-rpc.pops.one/websocket` (verified `101 Switching
  Protocols`) |

  ### Testnet

  | Section | Removed | Reason |
  |---|---|---|
  | Faucets | `Axelar faucet` (`faucet.testnet.axelar.dev`) | Removed |
  | Faucets | `Faucet by All That Node` | Removed |
  | REST API docs | entire section | Both Swagger and OpenAPI links pointed at imperator (timeout); qubelabs LCD does not serve `/static/` |
  | RPC | `https://rpc-axelar-testnet.imperator.co:443` | Connection timeout |
  | RPC | `https://axelar-rpc-1.staketab.org:443` | Stuck at height 8854769 since 2023-07-31 (`catching_up=true`) |
  | LCD | `https://lcd-axelar-testnet.imperator.co` | Connection timeout |
  | LCD | `https://axelar-rest-1.staketab.org` | Same staketab node — stale since 2023 |
  | LCD | `https://axelar-archrest.chainode.tech` | Connection timeout |
  | gRPC | `axelar-archgrpc.chainode.tech:443` | Connection timeout |
  | Websocket | `wss://rpc-axelar-testnet.imperator.co/websocket` | Connection timeout |

  ### Testnet additions

  - `https://axelar-testnet-rpc.polkachu.com:443`
  - `https://tm.axelar-testnet.lava.build:443`

  ### Operational after cleanup

  **Mainnet**

  | Partner | RPC | LCD | gRPC | WS |
  |---|---|---|---|---|
  | pops.one | ✓ | | | ✓ |
  | qubelabs | ✓ | ✓ | ✓ | |
  | polkachu | ✓ | ✓ | ✓ | |
  | validatrium | ✓ | ✓ | | |
  | publicnode | ✓ | | | |

  **Testnet**

  | Partner | RPC | LCD | gRPC | WS |
  |---|---|---|---|---|
  | qubelabs | ✓ | ✓ | | |
  | polkachu | ✓ | | | |
  | lava.build | ✓ | | ✓ | ✓ |

  ### How endpoints were tested

  - RPC: `curl <url>/status` → `result.sync_info.latest_block_height` + `catching_up`
  - LCD: `curl <url>/cosmos/base/tendermint/v1beta1/node_info`
  - gRPC: `axelard q bank params --grpc-addr <addr> [--grpc-insecure]`
  - Websocket: `curl` with `Connection: Upgrade`, `Upgrade: websocket` headers, expect HTTP 101
  
Closes CPI-31