### PR TITLE
docs(xrpl-its): clarify gas_fee_amount semantics for XRP and IOU sources

### DIFF
--- a/src/content/docs/dev/send-tokens/xrpl/xrpl-its.mdx
+++ b/src/content/docs/dev/send-tokens/xrpl/xrpl-its.mdx
@@ -1,11 +1,12 @@
+import { Callout } from "/src/components/callout";
 
 # XRPL Interchain Token Service
 
-The XRPL Blockchain is unique in comparison to other blockchains integrated with Axelar. Unlike other blockchains, XRPL does not support smart contracts. As such there is no Interchain Token Service contract deployed on the chain the way there is with other EVM and non-EVM blockchain integrations.
+The XRPL Blockchain is unique in comparison to other blockchains integrated with Axelar. Unlike other blockchains, XRPL does not support smart contracts. As such there is no Interchain Token Service contract deployed on the chain the way there is with other EVM and non-EVM blockchain integrations; the same XRPL Multisig Gateway account that handles GMP also handles ITS transfers, and the deployment configs refer to that single address as both `AxelarGateway` and `InterchainTokenService`.
 
 ## XRPL Gateway
 
-The integration leverages the [XRPL Multisig Signing](https://xrpl.org/docs/concepts/accounts/multi-signing) account type to facilitate token transfers. The [gateway](https://github.com/commonprefix/axelar-amplifier/blob/xrpl/contracts/xrpl-multisig-prover/src/xrpl_multisig.rs) is controlled by the [Axelar Verifier set](https://axelarscan.io/verifiers).  
+The integration leverages the [XRPL Multisig Signing](https://xrpl.org/docs/concepts/accounts/multi-signing) account type to facilitate token transfers. The [gateway](https://github.com/commonprefix/axelar-amplifier/blob/xrpl/contracts/xrpl-multisig-prover/src/xrpl_multisig.rs) is controlled by the [Axelar Verifier set](https://axelarscan.io/verifiers).
 
 The testnet address for the XRPL Gateway is: [rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2](https://testnet.xrpl.org/accounts/rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2).
 
@@ -13,81 +14,171 @@ The mainnet address for the XRPL Gateway is: [rfmS3zqrQrka8wVyhXifEeyTwe8AMz2Yhw
 
 Axelar's integration to XRPL allows for the cross-chain transfer of both the XRPL native token (XRP itself) as well as custom tokens ([IOU](https://learn.xrpl.org/glossary/iou/)).
 
+## Transfer Token
 
-### Transfer Token
+The interchain transfer flow is similar to that of the regular [GMP flow](/dev/general-message-passing/xrpl/xrpl-gmp/). As with the regular GMP flow, you send a [payment transaction](https://xrpl.org/docs/references/protocol/transactions/types/payment) to the Gateway account, but with `interchain_transfer` as the `type` memo rather than `call_contract`.
 
-The interchain transfer flow is similar to that of the regular [GMP flow](/dev/general-message-passing/xrpl/xrpl-gmp/). As with the regular GMP flow, users will be sending a [payment transaction](https://xrpl.org/docs/references/protocol/transactions/types/payment) to the Gateway account. The main difference is that the `MessageType` being sent to the Gateway is an `interchain_transfer` message type instead of a `call_contract` message.
+The Gateway becomes the custodian of your token on XRPL while the transfer is routed via the [ITS Hub](/dev/send-tokens/interchain-tokens/its-hub/) to the destination chain (and back, when bridged back).
 
-When transferring a token out of XRPL you will be sending the token from your XRPL account to the Gateway contract. The Gateway will be the custodian of your token on XRPL while it is sent via ITS hub to the destination chain until is bridged back to XRPL. Sending a token will be similar to sending a regular GMP message in that the information that is sent to the Gateway (and eventually to ITS hub) will need to be specified in the [memo](https://xrpl.org/docs/references/protocol/transactions/common-fields#memos-field) field of the transaction.
+### Required memos
 
-What needs to be specified in the `memo` is the following:
+You attach the following memos to the payment. Each field name goes into `MemoType` and the value into `MemoData`, both hex-encoded ASCII.
 
-1. `type`: The type of the transaction (which will be `interchain_transfer`)
-1. `destination_address`: The address of the destination contract on the destination chain.
-1. `destination_chain`: The name of the destination chain.
-1. `gas_fee_amount`: The amount to be used to cover the the [cross-chain transaction fees](/dev/gas-service/intro/).
-1. `payload`: A message to be sent along with the cross-chain asset transfer. This parameter is only needed if you are sending a gmp message, can be ignored if you are simply sending a token without an executable message.
+1. `type`: always `interchain_transfer` for ITS transfers.
+1. `destination_address`: the recipient address on the destination chain, hex-encoded **without** any `0x` prefix.
+1. `destination_chain`: the [Axelar chain name](https://axelarscan.io/resources/chains) of the destination chain (for example `xrpl-evm`, `ethereum`, `hedera`).
+1. `gas_fee_amount`: the portion of `Amount` set aside to pay [cross-chain transaction fees](/dev/gas-service/intro/). See [Encoding `gas_fee_amount`](#encoding-gas_fee_amount) for the required format.
+1. `payload`: ABI-encoded calldata for the destination Executable. Include this memo **only** when the destination address is a smart contract that you want to invoke. When the destination is an externally-owned account (EOA) or any address that is not an executing contract, omit the `payload` memo entirely; an empty or zero-length payload is still treated as a GMP call and will fail.
 
-Each of the previously mentioned fields will be passed into the memo as a `MemoType` as an encoded hex. You can then specify the value for each of these fields in the `MemoData` field, also encoded in hex.   
+### How `gas_fee_amount` relates to `Amount`
 
-A full `JSON` example of the entire required XRPL Interchain Transfer fields can be as follows:
+A single XRPL Payment carries one `Amount`. The validators interpret that `Amount` as **both** the amount to bridge **and** the source of gas:
+
+```
+transfer_amount = Amount - gas_fee_amount
+```
+
+The `transfer_amount` (in the same currency as `Amount`) is what the ITS Hub forwards to the destination chain. The `gas_fee_amount` portion is credited to the Axelar gas service to pay relayers along the cross-chain route.
+
+Two consequences worth keeping in mind:
+
+- **The initial gas allocation is paid in the same asset that is being sent.** A single XRPL Payment cannot carry an `Amount` and a `gas_fee_amount` in different currencies. If you later need to top up gas (for example because the initial allocation was too low, or because you want to add XRP gas to an IOU transfer), use [Add Gas](#insufficient-gas), which is a separate Payment and accepts any supported token.
+- **`Amount` must include the gas.** If you want the recipient on the destination chain to receive `X` tokens, then `Amount = X + gas_fee_amount` on the source side.
+
+<Callout type="warning">
+  `gas_fee_amount` **must be strictly less than `Amount`**. Otherwise Axelar
+  verifiers reject the message, the payment is never indexed on Axelarscan,
+  and the funds remain at the Gateway multisig without an automated refund
+  path.
+</Callout>
+
+### Encoding `gas_fee_amount`
+
+The format of the `gas_fee_amount` memo depends on the type of `Amount` in the Payment. There is no per-memo currency or issuer field; those are inherited from `Amount`.
+
+| `Amount` type             | Source token | `gas_fee_amount` memo format                                                                       |
+| ------------------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| Drops string, e.g. `"1000000"` | XRP          | An integer drops string (parsed as a `u64`), e.g. `"100000"` for 0.1 XRP gas.                      |
+| Issued object             | IOU          | A decimal string (parsed as an `XRPLTokenAmount`) in the same `currency` and `issuer` as `Amount`. |
+
+<Callout type="warning">
+  A memo that does not match the format expected for the `Amount` type
+  (for example a decimal like `"0.18"` in an XRP/drops payment) cannot be
+  verified by Axelar, so the message is never indexed on Axelarscan and
+  [Add Gas](#insufficient-gas) cannot recover it.
+</Callout>
+
+### Example: sending XRP
+
+This example sends 1 XRP, allocating 0.1 XRP to gas. The destination chain receives the equivalent of 0.9 XRP.
 
 ```json
 {
     TransactionType: "Payment",
-    Account: user.address, 
-    Amount: "1000000", // (1 xrp)
-    // Amount: { // alternatively, an IOU token amount can be used to cover gas fees
-    //     currency: "ABC", // IOU's currency code
-    //     issuer: "r4DVHyEisbgQRAXCiMtP2xuz5h3dDkwqf1", // IOU issuer's account address
-    //     value: "1" // IOU amount to bridge (in this case, 1 ABC.r4DVH), *including* gas fee amount
-    // },
-    Destination: gateway.address, 
+    Account: "<user XRPL address>",
+    Destination: "<gateway XRPL address>",
+    Amount: "1000000", // 1 XRP, in drops
     Memos: [
         {
             Memo: {
-                MemoType: "74797065", // hex("msg type")
-                MemoData: "696e746572636861696e5f7472616e73666572" // hex("interchain_transfer")
+                MemoType: "74797065", // hex("type")
+                MemoData: "696E746572636861696E5F7472616E73666572", // hex("interchain_transfer")
             },
         },
         {
             Memo: {
-                MemoType: "64657374696e6174696f6e5f61646472657373", // hex("destination_address")
-                MemoData: "30413930633041663142303766364143333466333532303334384462666165373342446133353845" // hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E"), in this case: (0x is omitted)
+                MemoType: "64657374696E6174696F6E5F61646472657373", // hex("destination_address")
+                MemoData: "30413930633041663142303766364143333466333532303334384462666165373342446133353845", // hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E"), an EVM address with no 0x prefix
             },
         },
         {
             Memo: {
                 MemoType: "64657374696E6174696F6E5F636861696E", // hex("destination_chain")
-                MemoData: "7872706c2d65766d2d6465766e6574", // destination chain, hex encoded - hex("xrpl-evm-devnet"), in this case
+                MemoData: "7872706C2D65766D", // hex("xrpl-evm")
             },
         },
         {
             Memo: {
-                MemoType: "6761735f6665655f616d6f756e74", // hex("gas_fee_amount")
-                MemoData: "30", // amount of tokens to allocate to gas fees
-            },
-        },
-        { // Only include this Memo object when performing a GMP call:
-            Memo: {
-                MemoType: "7061796c6f6164", // hex("payload")
-                // abi-encoded payload/data with which to call the Executable destination contract address:
-                MemoData: "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000e474d5020776f726b7320746f6f3f000000000000000000000000000000000000",
+                MemoType: "6761735F6665655F616D6F756E74", // hex("gas_fee_amount")
+                MemoData: "313030303030", // hex("100000"), i.e. 100000 drops = 0.1 XRP
             },
         },
     ],
 }
 ```
 
-### Example
+Axelar parses the `gas_fee_amount` memo as a `u64` drops value (0.1 XRP), computes `transfer_amount = 1 XRP - 0.1 XRP = 0.9 XRP`, and the ITS Hub forwards the equivalent of 0.9 XRP to the destination chain.
+
+The hex casing of `MemoType` and `MemoData` does not matter on submission; the XRPL canonical wire format is uppercase, which is what XRPL nodes and explorers will return.
+
+### Example: sending an IOU
+
+This example sends `1` of an IOU (currency `ABC`, issuer `r4DVHyEisbgQRAXCiMtP2xuz5h3dDkwqf1`), allocating `0.05` to gas. The destination chain receives the equivalent of `0.95 ABC`.
+
+```json
+{
+    TransactionType: "Payment",
+    Account: "<user XRPL address>",
+    Destination: "<gateway XRPL address>",
+    Amount: {
+        currency: "ABC",                                  // IOU currency code
+        issuer: "r4DVHyEisbgQRAXCiMtP2xuz5h3dDkwqf1",     // IOU issuer
+        value: "1",                                       // 1 ABC, including the gas portion
+    },
+    Memos: [
+        {
+            Memo: {
+                MemoType: "74797065", // hex("type")
+                MemoData: "696E746572636861696E5F7472616E73666572", // hex("interchain_transfer")
+            },
+        },
+        {
+            Memo: {
+                MemoType: "64657374696E6174696F6E5F61646472657373", // hex("destination_address")
+                MemoData: "30413930633041663142303766364143333466333532303334384462666165373342446133353845", // hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E"), an EVM address with no 0x prefix
+            },
+        },
+        {
+            Memo: {
+                MemoType: "64657374696E6174696F6E5F636861696E", // hex("destination_chain")
+                MemoData: "7872706C2D65766D", // hex("xrpl-evm")
+            },
+        },
+        {
+            Memo: {
+                MemoType: "6761735F6665655F616D6F756E74", // hex("gas_fee_amount")
+                MemoData: "302E3035", // hex("0.05"), i.e. 0.05 ABC
+            },
+        },
+    ],
+}
+```
+
+Axelar parses the `gas_fee_amount` memo as an `XRPLTokenAmount` in the same `(currency, issuer)` as `Amount` (here `0.05 ABC`), computes `transfer_amount = 1 - 0.05 = 0.95 ABC`, and the ITS Hub forwards `0.95 ABC` to the destination chain.
+
+### Sending a GMP message with the transfer
+
+To trigger an Executable on the destination chain, include a fifth memo of type `payload` with the ABI-encoded calldata:
+
+```json
+{
+    Memo: {
+        MemoType: "7061796C6F6164", // hex("payload")
+        // ABI-encoded calldata to invoke the destination Executable; example payload below encodes the string "GMP works too?"
+        MemoData: "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000E474D5020776F726B7320746F6F3F000000000000000000000000000000000000",
+    },
+}
+```
+
+The `destination_address` for this case is the contract address of the Executable on the destination chain. Omit the `payload` memo for plain token transfers.
+
+## Example
 
 A full example can be found [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/main/xrpl/interchain-transfer.js).
 
-The example makes use of the [XRPL Client library](https://www.npmjs.com/package/xrpl)
+The example makes use of the [XRPL Client library](https://www.npmjs.com/package/xrpl), which simplifies connecting to the XRPL network, building transactions, signing them, and submitting them.
 
-The XRPL client simplifies the process of connecting to the XRPL network, building transactions, signing them, and submitting them for processing. Key components of the XRPL client include:
-
-The key function in this example is the `interchainTransfer()` function written out as follows.
+The key function in this example is `interchainTransfer()`:
 
 ```js
 async function interchainTransfer(_config, wallet, client, chain, options, args) {
@@ -109,18 +200,32 @@ async function interchainTransfer(_config, wallet, client, chain, options, args)
 }
 ```
 
-This function constructs the `memo` that will be used for the transaction, passing in the `type`, `destination_address`, `destination_chain`, and `gas_fee_amount`. The [request](https://js.xrpl.org/classes/Client.html#request) functionality of the XRPL client is then used to submit a [signed](https://js.xrpl.org/classes/Wallet.html#sign) transaction.
+Note that `hex(options.gasFeeAmount)` performs no format validation. Make sure the string you pass matches the format required by the `Amount` type as set out in [Encoding `gas_fee_amount`](#encoding-gas_fee_amount).
 
-To interact with the example run the following command
+### Sending XRP
+
+To send 1 XRP with 0.1 XRP allocated to gas:
 
 ```bash
-node xrpl/interchain-transfer.js -e testnet  -n xrpl XRP 1 xrpl-evm 0x312dba807EAE77f01EF3dd21E885052f8F617c5B --gasFeeAmount 100000
+node xrpl/interchain-transfer.js -e testnet -n xrpl XRP 1 xrpl-evm 0x312dba807EAE77f01EF3dd21E885052f8F617c5B --gasFeeAmount 100000
 ```
 
-This will send an ITS transfer to the `0x312dba807EAE77f01EF3dd21E885052f8F617c5B` address on the `XRPL-EVM` chain.
+`--gasFeeAmount` is an integer drops string (`100000` drops = 0.1 XRP).
 
-Once the command is run you should as a [transaction](https://testnet.axelarscan.io/gmp/0x8032a4695f4b663a7699da81760997baabb663dea4afc25b78b3434553fcd09d) on the Axelarscan explorer where you can track the entire cross-chain transaction.
+### Sending an IOU
 
-#### Insufficient Gas Error
+To send `1 ABC.r4DVHyEisbgQRAXCiMtP2xuz5h3dDkwqf1` with `0.05 ABC` allocated to gas:
 
-In the event of an `insufficient gas` error, you can unblock the underfunded transaction by running the [Add Gas](/dev/general-message-passing/xrpl/xrpl-gmp/#add-gas) top up the missing funds. 
+```bash
+node xrpl/interchain-transfer.js -e testnet -n xrpl ABC.r4DVHyEisbgQRAXCiMtP2xuz5h3dDkwqf1 1 xrpl-evm 0x312dba807EAE77f01EF3dd21E885052f8F617c5B --gasFeeAmount 0.05
+```
+
+`--gasFeeAmount` is a decimal string in the same currency as the token argument.
+
+Once the command is run, you can track the cross-chain transaction on the [Axelarscan explorer](https://testnet.axelarscan.io/).
+
+## Insufficient gas
+
+If `gas_fee_amount` is well-formed but not enough to cover the actual Axelar-side relaying costs, the message is indexed on the GMP API as `INSUFFICIENT_GAS` and you can unblock it by topping up via [Add Gas](/dev/general-message-passing/xrpl/xrpl-gmp/#add-gas).
+
+This recovery path only works for messages that Axelar verifiers were able to verify in the first place. Payments whose `gas_fee_amount` is malformed or not strictly less than `Amount` are never indexed on Axelarscan and cannot be recovered through Add Gas; validate the memo format on the source side to avoid that case.


### PR DESCRIPTION
The XRPL ITS page covered the happy path for XRP-source transfers but left the format and invariants of the `gas_fee_amount` memo implicit, so IOU-source integrators had to infer the contract by reading source. Rewrite the page to:

- State the `transfer_amount = Amount - gas_fee_amount` relationship, so it is unambiguous that `Amount` must include the gas portion and that gas is paid in the same asset that is being sent.
- Spell out the format rule for `gas_fee_amount` in a table keyed off the XRPL `Payment.Amount` type (Drops → u64 drops integer string; Issued → XRPLTokenAmount decimal string, currency/issuer inherited from `Amount`).
- Add a warning that `gas_fee_amount` must be strictly less than `Amount`, and a separate warning that a malformed memo cannot be verified by Axelar, leaving funds at the multisig with no Add Gas recovery path.
- Provide a complete IOU end-to-end JSON example alongside the existing XRP example, plus a corresponding CLI invocation.
- Note in the Insufficient Gas section that Add Gas only recovers payments that were indexed in the first place, so users can self-diagnose stuck transfers.