### PR TITLE
Add Valopers explorer

### DIFF
--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -27,6 +27,10 @@
         {
           "title": "Ping.Pub",
           "value": "https://ping.pub/axelar"
+        },
+        {
+          "title": "Valopers",
+          "value": "https://axelar.valopers.com"
         }
       ]
     },
@@ -154,6 +158,10 @@
         {
           "title": "ScanRun",
           "value": "https://scanrun.io/axelar-testnet"
+        },
+        {
+          "title": "Valopers",
+          "value": "https://testnet.axelar.valopers.com"
         }
       ]
     },


### PR DESCRIPTION
Title: Add Valopers explorer

Adds Valopers to the Axelar mainnet and testnet block explorer lists.

Mainnet: https://axelar.valopers.com
Testnet: https://testnet.axelar.valopers.com
