### PR TITLE
docs(txduration): add live per-chain finality measurements reference

### DIFF
--- a/src/content/docs/learn/txduration.mdx
+++ b/src/content/docs/learn/txduration.mdx
@@ -71,3 +71,7 @@ This data is available on the [Axelarscan block explorer under the heading **GMP
 | Celo | 12 seconds | 1 block
 | Arbitrum | 19:06 minutes | 1000000 blocks
 | Base | 24 minutes | 1000000 blocks
+
+### Live per-chain finality measurements
+
+For a live, continuously updated comparison of finality time across major L1 chains, see the [OpenChainBench L1 finality benchmark](https://openchainbench.com/benchmarks/l1-finality). It measures wall-clock seconds between latest and finalized blocks for 11 L1s (Ethereum, Solana, BNB, Avalanche, SUI, Stellar, TON, Bitcoin, Litecoin, TRON, Monero), refreshed every 10 seconds, under an open methodology ([source, MIT](https://github.com/ChainBench/OpenChainBench), data CC-BY-4.0). Values in the table above are typical observations from `axelarscan.io/interchain`; live measurements can drift with network conditions and are useful for integrators sanity-checking assumed finality windows against current chain state.


### PR DESCRIPTION
## Summary

Append a small subsection at the end of `src/content/docs/learn/txduration.mdx` pointing readers to a live third-party benchmark of L1 finality time. The existing table on that page is sourced from `axelarscan.io/interchain` with typical observed values; this addition gives integrators a complementary live-data source to sanity-check assumed finality windows against current network conditions.

## Why

The `Common Finality Time for Interchain Transactions` table lists useful reference values (Ethereum ~16 min, Avalanche ~3 s, Linea ~81 min, etc.) but these are typical snapshots. During upgrades, congestion, or network anomalies, actual finality can drift meaningfully. Devs building cross-chain apps often want a live source to sanity-check the assumed number.

[OpenChainBench](https://openchainbench.com/benchmarks/l1-finality) measures wall-clock seconds between latest and finalized blocks for 11 L1s (Ethereum, Solana, BNB, Avalanche, SUI, Stellar, TON, Bitcoin, Litecoin, TRON, Monero), refreshed every 10 s. Not a replacement for the existing table, a complement.

## About OpenChainBench

- Open methodology: https://openchainbench.com/methodology
- Source (MIT): https://github.com/ChainBench/OpenChainBench
- Data license: CC-BY-4.0
- Multi-region measurement (3 regions), 10 s refresh
- Not affiliated with Axelar; measures Axelar-connected chains among many others
- Funded by Mobula; all chains including funder-adjacent are measured identically

## Test plan

- [x] Single-file addition, 8 lines appended after the existing finality time table
- [x] No structural change, no table modification, no existing content touched
- [x] Preserves the existing narrative and axelarscan.io reference above

Happy to reword, move to a callout, or drop entirely if this does not fit the docs' tone.