### PR TITLE
docs: add third-party GMP latency monitor to the monitoring page

### DIFF
--- a/src/content/docs/resources/axelarscan/monitoring.mdx
+++ b/src/content/docs/resources/axelarscan/monitoring.mdx
@@ -37,3 +37,9 @@ import { Callout } from "/src/components/callout";
 ## 2. AxelarJS SDK
 
 See the SDK docs section, [Query transaction status by txHash](/dev/axelarjs-sdk/tx-status-query-recovery#query-transaction-status-by-txhash).
+
+## 3. Third-party monitoring
+
+Community-run monitors that consume the AxelarScan API and publish continuous latency measurements:
+
+- [OpenChainBench Axelar GMP Latency](https://openchainbench.com/benchmarks/axelar-gmp-latency) computes per-source-chain histograms from `time_spent.call_confirm` and `time_spent.total` on the public `searchGMP` endpoint, refreshed every 60 seconds. Covers Ethereum, Polygon, Base, Moonbeam, and Osmosis at launch. Source code: [ChainBench/OpenChainBench](https://github.com/ChainBench/OpenChainBench/tree/main/harnesses/axelar-gmp-latency).


### PR DESCRIPTION
Adds a "Third-party monitoring" section under `resources/axelarscan/monitoring.mdx` linking to OpenChainBench's Axelar GMP latency benchmark. The bench consumes AxelarScan's own `searchGMP` payload (specifically the pre-computed `time_spent.call_confirm` and `time_spent.total` fields) and publishes rolling percentiles per source chain updated every 60 seconds.

Placed alongside the AxelarScan UI and AxelarJS SDK sections so users looking for delivery-latency observability have a passive-monitoring option in the same place they'd look for the interactive tracker. Happy to move it under `resources/` as a standalone page if the maintainers prefer.